### PR TITLE
fix: detach WebView bridges before source updates

### DIFF
--- a/.changeset/modern-audio-native.md
+++ b/.changeset/modern-audio-native.md
@@ -5,3 +5,5 @@
 
 Introduce the typed framework-independent audio controller and the Vue 3 player, while preserving
 the documented Vue component name, plugin install path, legacy props, legacy events and slots.
+WebView host bridges are protocol-neutral and can be detached without receiving later source or
+state events.

--- a/.changeset/modern-audio-native.md
+++ b/.changeset/modern-audio-native.md
@@ -1,9 +1,10 @@
 ---
-"@trsoliu/audio-core": major
-"vue-audio-native": major
+'@trsoliu/audio-core': major
+'vue-audio-native': major
 ---
 
 Introduce the typed framework-independent audio controller and the Vue 3 player, while preserving
 the documented Vue component name, plugin install path, legacy props, legacy events and slots.
 WebView host bridges are protocol-neutral and can be detached without receiving later source or
 state events.
+Package publication is pinned to the official npm registry.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - 'codex/**'
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ package changelogs are managed by Changesets.
 
 ## Unreleased
 
+- Fixed WebView Bridge teardown so removing an adapter happens before a simultaneous source switch.
+
 ### Added
 
 - Typed, framework-independent `@trsoliu/audio-core` controller and public state contract.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ package changelogs are managed by Changesets.
 ## Unreleased
 
 - Fixed WebView Bridge teardown so removing an adapter happens before a simultaneous source switch.
+- Pinned publishable packages to the official npm registry so local mirror settings cannot redirect a release.
 
 ### Added
 

--- a/docs/api/index.mdx
+++ b/docs/api/index.mdx
@@ -14,7 +14,10 @@ description: Vue 组件、composable、共享类型、事件、插槽与命令�
 - `useAudioPlayer()`；
 - `createAudioController()`、能力检测和时间格式化工具；
 - `AudioTrack`、`AudioSnapshot`、`AudioPlayerError`、`AudioPlayerHandle`、
-  `AudioPlayerBridge` 等公共类型。
+`AudioPlayerBridge` 等公共类型。
+
+Headless `useAudioPlayer()` 接受协议无关的 `bridge`；从响应式 options 中移除它会解绑旧
+宿主。直接使用 controller 时可传 `bridge: null` 完成同一操作。
 
 ## 现代 props
 

--- a/docs/wiki/browser-webview.mdx
+++ b/docs/wiki/browser-webview.mdx
@@ -27,5 +27,8 @@ Bridge 只接收结构化 `statechange`、`trackchange` 和 `error` 事件。它
 不假定方法名，也不在模块加载时执行。宿主可以把事件映射到 JS bridge、message handler
 或其他容器协议。
 
+`AudioControllerOptions.bridge` 接受 `null` 作为显式解绑；Vue composable 中移除 `bridge`
+也会先断开旧宿主，再处理同一次更新里的 source 变化，避免 WebView 销毁后继续收事件。
+
 自动化浏览器测试不能替代 WebView 音频会话、后台恢复和路由行为。稳定版条件以
 [真机冒烟记录](../device-smoke/)为准。

--- a/docs/wiki/release.mdx
+++ b/docs/wiki/release.mdx
@@ -14,6 +14,18 @@ description: beta、stable、npm dist-tag、Trusted Publishing 与干净消费�
 5. 在完全干净的 Vite、Nuxt、React 和 Next 消费者中验证 registry 包。
 6. 真机证据完成前保持 beta；完成后才设置 Vue 2 `legacy` 并发布稳定 1.0。
 
+## 首次 beta 引导发布
+
+新包尚未建立 Trusted Publisher 时，从包目录执行：
+
+```bash
+npm whoami --registry=https://registry.npmjs.org
+npm publish --tag next --access public --provenance=false
+```
+
+三个发布包都通过 `publishConfig.registry` 固定到官方 npm registry，不受本机安装镜像配置
+影响。`--provenance=false` 只用于首次 beta 引导；稳定版必须由 GitHub OIDC 生成 provenance。
+
 ## 证据不是声明
 
 本地 workspace link、成功的 `npm pack` 或桌面浏览器 E2E 都不能证明 registry 安装和宿主

--- a/packages/audio-core/README.md
+++ b/packages/audio-core/README.md
@@ -51,6 +51,9 @@ const controller = createAudioController({
 })
 ```
 
+Call `controller.updateOptions({ bridge: null })` to detach the host before a WebView is recycled or
+its transport is replaced. No later track, state or error event is delivered to the old bridge.
+
 Host exceptions are isolated from playback. `detectAudioCapabilities()` reports custom-control,
 download, Media Session, native HLS, Pointer Events and touch capabilities without parsing the user
 agent.

--- a/packages/audio-core/package.json
+++ b/packages/audio-core/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "license": "MIT",
   "author": "trsoliu",
-  "homepage": "https://github.com/trsoliu/vue-audio-native#readme",
+  "homepage": "https://trsoliu.github.io/vue-audio-native/",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/trsoliu/vue-audio-native.git",

--- a/packages/audio-core/package.json
+++ b/packages/audio-core/package.json
@@ -60,7 +60,8 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true
+    "provenance": true,
+    "registry": "https://registry.npmjs.org/"
   },
   "size-limit": [
     {

--- a/packages/audio-core/src/types.ts
+++ b/packages/audio-core/src/types.ts
@@ -112,7 +112,7 @@ export interface AudioPlayerHandle {
 
 export interface AudioControllerOptions extends AudioInput {
   autoplay?: boolean
-  bridge?: AudioPlayerBridge
+  bridge?: AudioPlayerBridge | null
   exclusive?: boolean
   group?: string
   mediaSession?: boolean

--- a/packages/audio-core/tests/controller.test.ts
+++ b/packages/audio-core/tests/controller.test.ts
@@ -568,4 +568,17 @@ describe('createAudioController', () => {
       type: 'error',
     })
   })
+
+  it('accepts an explicit bridge reset and stops emitting host events', () => {
+    const audio = new FakeAudioElement()
+    const emit = vi.fn()
+    const controller = createAudioController({ bridge: { emit }, src: 'one.mp3' })
+    controller.attach(audio.asAudioElement())
+    emit.mockClear()
+
+    controller.updateOptions({ bridge: null })
+    audio.emit('canplay')
+
+    expect(emit).not.toHaveBeenCalled()
+  })
 })

--- a/packages/vue-audio-native/package.json
+++ b/packages/vue-audio-native/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "license": "MIT",
   "author": "trsoliu",
-  "homepage": "https://github.com/trsoliu/vue-audio-native#readme",
+  "homepage": "https://trsoliu.github.io/vue-audio-native/",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/trsoliu/vue-audio-native.git",

--- a/packages/vue-audio-native/package.json
+++ b/packages/vue-audio-native/package.json
@@ -82,7 +82,8 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true
+    "provenance": true,
+    "registry": "https://registry.npmjs.org/"
   },
   "size-limit": [
     {

--- a/packages/vue-audio-native/src/use-audio-player.ts
+++ b/packages/vue-audio-native/src/use-audio-player.ts
@@ -20,6 +20,7 @@ import type {
 function runtimeOptions(options: AudioControllerOptions): AudioControllerOptions {
   const nextOptions: AudioControllerOptions = {
     autoplay: options.autoplay ?? false,
+    bridge: options.bridge ?? null,
     exclusive: options.exclusive ?? false,
     group: options.group ?? 'default',
     mediaSession: options.mediaSession ?? false,
@@ -30,7 +31,6 @@ function runtimeOptions(options: AudioControllerOptions): AudioControllerOptions
     volume: options.volume ?? 1,
     waitBuffer: options.waitBuffer ?? true,
   }
-  if (options.bridge !== undefined) nextOptions.bridge = options.bridge
   return nextOptions
 }
 
@@ -57,16 +57,16 @@ export function useAudioPlayer(
     (element) => controller.attach(element),
     { flush: 'sync' },
   )
+  watch(
+    () => runtimeOptions(getOptions()),
+    (nextOptions) => controller.updateOptions(nextOptions),
+    { deep: true, flush: 'sync' },
+  )
   const updateInput = (): void => controller.setInput(audioInput(getOptions()))
   watch(
     () => JSON.stringify(audioInput(getOptions())),
     () => updateInput(),
     { flush: 'sync' },
-  )
-  watch(
-    () => runtimeOptions(getOptions()),
-    (nextOptions) => controller.updateOptions(nextOptions),
-    { deep: true, flush: 'sync' },
   )
 
   onScopeDispose(() => {

--- a/packages/vue-audio-native/tests/component.test.ts
+++ b/packages/vue-audio-native/tests/component.test.ts
@@ -1,4 +1,4 @@
-import type { AudioTrack } from '@trsoliu/audio-core'
+import type { AudioControllerOptions, AudioTrack } from '@trsoliu/audio-core'
 import { enableAutoUnmount, mount } from '@vue/test-utils'
 import { createApp, defineComponent, h, nextTick, ref } from 'vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -313,5 +313,25 @@ describe('VueAudioNative', () => {
     expect(result?.snapshot.value.volume).toBe(0.4)
     wrapper.unmount()
     expect(result?.controls.getElement()).toBeNull()
+  })
+
+  it('removes the WebView bridge before switching a headless source', () => {
+    const emit = vi.fn()
+    const options = ref<AudioControllerOptions>({
+      bridge: { emit },
+      src: '/bridged.mp3',
+    })
+    const Harness = defineComponent({
+      setup() {
+        const player = useAudioPlayer(options)
+        return () => h('audio', { ref: player.audioRef })
+      },
+    })
+    mount(Harness)
+    emit.mockClear()
+
+    options.value = { src: '/detached.mp3' }
+
+    expect(emit).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary

- add an explicit nullable Bridge reset to the shared audio contract
- clear Vue headless Bridge options before processing a simultaneous source change
- add core and Vue regressions proving recycled WebViews receive no later events
- point publishable package homepages at the Silen GitHub Pages site
- pin package publishing to the official npm registry and document the initial beta bootstrap
- avoid duplicate push and pull-request CI runs

## Verification

- `pnpm security:audit`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:coverage` (core 53/53, Vue 14/14)
- `pnpm build`
- `pnpm docs:build && pnpm docs:index && pnpm docs:audit && pnpm docs:eval`
- `pnpm test:pack`
- `pnpm test:e2e` (25/25)
- `npm publish --dry-run --tag next --access public --provenance=false --json` targets `https://registry.npmjs.org/`