### PR TITLE
ci: update Pages and artifact actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - run: pnpm exec playwright install --with-deps chromium firefox webkit
       - run: pnpm test:e2e
       - if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: playwright-report

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -38,8 +38,8 @@ jobs:
       - run: pnpm docs:index
       - run: pnpm docs:audit
       - run: pnpm docs:eval
-      - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/configure-pages@v6
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: docs/.silen/dist
 
@@ -52,4 +52,4 @@ jobs:
     steps:
       - name: Deploy GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

- update `actions/configure-pages` to v6
- update `actions/upload-pages-artifact` and `actions/deploy-pages` to v5
- update browser artifacts to `actions/upload-artifact@v7`
- move all remaining GitHub-hosted action runtimes from Node 20 to Node 24

## Verification

- versions match the latest official major releases
- workflow YAML passes Prettier and `git diff --check`
- GitHub PR CI and post-merge Pages deployment are the runtime validation gates