### PR TITLE
docs: add Vue design contract

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,43 @@
+# Design boundaries
+
+Vue Audio Native is split into a framework-independent browser audio core and a thin Vue 3
+adapter. The public state contract belongs to `@trsoliu/audio-core`; framework integrations must
+translate that contract instead of creating their own playback state machines.
+
+## Ownership
+
+- `@trsoliu/audio-core` owns media events, source fallback, playlists, repeat behavior, buffered
+  ranges, structured errors, capability detection, exclusive groups, Media Session and the
+  protocol-neutral WebView Bridge.
+- `vue-audio-native` owns Vue lifecycle integration, legacy Vue API translation, component events,
+  slots, exposed controls, accessible markup and package styling.
+- Demo workspaces own shadcn-vue, Reka, Tailwind, Sonner and presentation-only assets. None of those
+  dependencies may enter a published package.
+
+## Runtime rules
+
+- Playback state is driven by standard media events. The implementation does not poll
+  `readyState`, keep background timers or inspect user-agent strings.
+- Importing either package is SSR safe. DOM and media objects are used only after a real
+  `HTMLAudioElement` is attached by the framework adapter.
+- Unsupported custom-control capabilities fall back to native audio controls. Media Session and
+  host Bridge integration are explicit opt-ins.
+- Multiple players are independent unless both `exclusive` and an identical `group` are set.
+- Waveforms render caller-provided peaks only; packages do not fetch or decode audio to derive
+  waveform data.
+
+## Public and compatibility surfaces
+
+- Vue 1.x targets Vue 3 while retaining the documented 0.x props, events, component name, slots and
+  plugin installation path. Vue 2 remains available from `vue-audio-native@legacy`.
+- `@trsoliu/audio-core` is the shared contract consumed by the separate React adapter repository.
+  Matching releases use exact prerelease versions and are published core → Vue → React.
+- React Native native SDKs, recording, DRM, transcoding, automatic waveform extraction and bundled
+  HLS engines remain outside the 1.0 scope.
+
+## Distribution boundaries
+
+Published packages contain ESM, CommonJS, declarations and standalone CSS. The Vue package also
+provides its documented browser bundle. Package CSS excludes Tailwind Preflight, global utilities,
+OKLCH and `color-mix()` output. Stable publication remains blocked until registry consumers and the
+required iOS, Android and HarmonyOS WebView smoke rows are verified.

--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ pnpm test:pack
 pnpm test:e2e
 ```
 
-文档站本地启动：`pnpm docs:dev --host 127.0.0.1 --port 5175`。项目地图见
-[`docs/project-map`](docs/project-map/index.mdx)，架构决策见 [`docs/adr`](docs/adr)，
+文档站本地启动：`pnpm docs:dev --host 127.0.0.1 --port 5175`。设计边界见
+[`DESIGN.md`](DESIGN.md)，项目地图见 [`docs/project-map`](docs/project-map/index.mdx)，
+架构决策见 [`docs/adr`](docs/adr)，
 浏览器支持边界见 [`docs/compatibility.md`](docs/compatibility.md)。合并到 `master` 后，
 GitHub Pages 会发布到 <https://trsoliu.github.io/vue-audio-native/>。
 


### PR DESCRIPTION
## Summary

- add the root design boundary document required by AGENTS.md
- link the design contract from the repository README
- document core, Vue adapter, Demo, compatibility and release ownership

## Verification

- pnpm docs:build
- pnpm docs:index
- pnpm docs:audit
- pnpm docs:eval
- pnpm exec prettier --check DESIGN.md README.md
- git diff --check