### PR TITLE
ci: deploy Silen agent contract

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -42,6 +42,7 @@ jobs:
       - uses: actions/upload-pages-artifact@v5
         with:
           path: docs/.silen/dist
+          include-hidden-files: true
 
   deploy:
     environment:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ package changelogs are managed by Changesets.
 - Pinned publishable packages to the official npm registry so local mirror settings cannot redirect a release.
 - Added a manual, gated GitHub Actions bootstrap for the first npm beta using a short-lived
   environment secret before permanent migration to OIDC Trusted Publishing.
+- Included hidden Silen output in the GitHub Pages artifact so the public Agent Contract under
+  `.well-known/silen` is deployed with the documentation site.
 
 ### Added
 

--- a/scripts/pages-workflow.test.ts
+++ b/scripts/pages-workflow.test.ts
@@ -1,0 +1,19 @@
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const repositoryRoot = resolve(import.meta.dirname, '..')
+const workflowPath = resolve(repositoryRoot, '.github/workflows/pages.yml')
+
+describe('GitHub Pages Agent Contract deployment', () => {
+  it('includes the generated .well-known directory in the Pages artifact', async () => {
+    const workflow = await readFile(workflowPath, 'utf8')
+    const uploadStepStart = workflow.indexOf('actions/upload-pages-artifact@')
+    const uploadStepEnd = workflow.indexOf('\n\n', uploadStepStart)
+    const uploadStep = workflow.slice(uploadStepStart, uploadStepEnd)
+
+    expect(uploadStepStart).toBeGreaterThan(-1)
+    expect(uploadStep).toContain('include-hidden-files: true')
+  })
+})


### PR DESCRIPTION
## Summary

- include hidden Silen build output in the GitHub Pages artifact
- restore the public .well-known/silen Agent Contract that was generated locally but excluded during upload
- add a workflow regression test and changelog entry

## Root cause

actions/upload-pages-artifact defaults include-hidden-files to false, so the successful Pages run omitted the entire .well-known directory. The Action continues to exclude .git and .github.

## Verification

All release gates passed locally, including 6/6 workflow contract tests, Silen audit and eval, package validation, and Playwright 25/25.