### PR TITLE
fix: tolerate npm registry propagation

### DIFF
--- a/.github/workflows/bootstrap-beta.yml
+++ b/.github/workflows/bootstrap-beta.yml
@@ -58,24 +58,46 @@ jobs:
       - name: Publish audio core beta when absent
         working-directory: packages/audio-core
         run: |
-          if npm view @trsoliu/audio-core@1.0.0-beta.1 version --registry=https://registry.npmjs.org >/dev/null 2>&1; then
+          registry_url='https://registry.npmjs.org/@trsoliu%2faudio-core/1.0.0-beta.1'
+          if curl --fail --silent --show-error --output /dev/null "$registry_url"; then
             echo '@trsoliu/audio-core@1.0.0-beta.1 is already published; skipping.'
           else
             npm publish --tag next --access public --registry=https://registry.npmjs.org
           fi
-          npm view @trsoliu/audio-core@1.0.0-beta.1 version --registry=https://registry.npmjs.org
+          for attempt in {1..12}; do
+            if curl --fail --silent --show-error --output /dev/null "$registry_url"; then
+              echo '@trsoliu/audio-core@1.0.0-beta.1 is visible on the registry.'
+              break
+            fi
+            if [[ "$attempt" == 12 ]]; then
+              echo '::error::@trsoliu/audio-core@1.0.0-beta.1 was not visible after 12 checks.'
+              exit 1
+            fi
+            sleep 5
+          done
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_BOOTSTRAP_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
       - name: Publish Vue beta when absent
         working-directory: packages/vue-audio-native
         run: |
-          if npm view vue-audio-native@1.0.0-beta.1 version --registry=https://registry.npmjs.org >/dev/null 2>&1; then
+          registry_url='https://registry.npmjs.org/vue-audio-native/1.0.0-beta.1'
+          if curl --fail --silent --show-error --output /dev/null "$registry_url"; then
             echo 'vue-audio-native@1.0.0-beta.1 is already published; skipping.'
           else
             npm publish --tag next --access public --registry=https://registry.npmjs.org
           fi
-          npm view vue-audio-native@1.0.0-beta.1 version --registry=https://registry.npmjs.org
+          for attempt in {1..12}; do
+            if curl --fail --silent --show-error --output /dev/null "$registry_url"; then
+              echo 'vue-audio-native@1.0.0-beta.1 is visible on the registry.'
+              break
+            fi
+            if [[ "$attempt" == 12 ]]; then
+              echo '::error::vue-audio-native@1.0.0-beta.1 was not visible after 12 checks.'
+              exit 1
+            fi
+            sleep 5
+          done
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_BOOTSTRAP_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
@@ -83,12 +105,15 @@ jobs:
         run: |
           npm dist-tag add @trsoliu/audio-core@1.0.0-beta.1 next --registry=https://registry.npmjs.org
           npm dist-tag add vue-audio-native@1.0.0-beta.1 next --registry=https://registry.npmjs.org
+          if npm dist-tag ls @trsoliu/audio-core --registry=https://registry.npmjs.org | grep --quiet '^latest: 1\.0\.0-beta\.1$'; then
+            npm dist-tag rm @trsoliu/audio-core latest --registry=https://registry.npmjs.org
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_BOOTSTRAP_TOKEN }}
       - name: Show published dist-tags
         run: |
-          npm view @trsoliu/audio-core dist-tags --json --registry=https://registry.npmjs.org
-          npm view vue-audio-native dist-tags --json --registry=https://registry.npmjs.org
+          npm dist-tag ls @trsoliu/audio-core --registry=https://registry.npmjs.org
+          npm dist-tag ls vue-audio-native --registry=https://registry.npmjs.org
 
   finalize-legacy:
     if: >-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ package changelogs are managed by Changesets.
   environment secret before permanent migration to OIDC Trusted Publishing.
 - Included hidden Silen output in the GitHub Pages artifact so the public Agent Contract under
   `.well-known/silen` is deployed with the documentation site.
+- Made the beta bootstrap tolerate npm registry propagation delays and remove an automatically
+  created `latest` tag when it points at the new core prerelease.
 
 ### Added
 

--- a/docs/adr/0003-bootstrap-npm-publishing.md
+++ b/docs/adr/0003-bootstrap-npm-publishing.md
@@ -23,9 +23,12 @@ Use a one-day npm Granular Access Token only for the first beta publications. St
 only to manual bootstrap publishing steps on the default branch.
 
 The Vue bootstrap workflow runs the complete release gates, publishes core before Vue with the
-`next` tag and is safe to rerun after a partial publication. The React repository uses the same
-pattern only after installing the public core beta. After all three betas and clean registry
-consumers pass, a separate confirmed workflow mode sets `vue-audio-native@0.1.41` to `legacy`.
+`next` tag and is safe to rerun after a partial publication. Exact registry version endpoints and a
+bounded propagation retry prevent a successful first publish from being mistaken for a failure.
+For a new package, the workflow removes `latest` only when npm automatically points it at the beta.
+The React repository uses the same pattern only after installing the public core beta. After all
+three betas and clean registry consumers pass, a separate confirmed workflow mode sets
+`vue-audio-native@0.1.41` to `legacy`.
 
 Immediately afterward, configure each package to trust its repository's `release.yml` workflow,
 delete both GitHub secrets and revoke the token. Stable releases use OIDC Trusted Publishing and
@@ -57,7 +60,7 @@ required npm package names, dist-tags or clean npm consumer verification.
 - GitHub Environment scoping, a default-branch condition, manual confirmation and complete gates
   constrain when publication can occur.
 - GitHub OIDC remains available for provenance during the token-authenticated bootstrap.
-- Idempotent version checks allow recovery if core succeeds and an adapter publication fails.
+- Idempotent exact-version checks allow recovery if core succeeds and an adapter publication fails.
 
 ### Negative
 
@@ -71,6 +74,8 @@ required npm package names, dist-tags or clean npm consumer verification.
 
 - Keep the expiry at one day and organization permissions at `No access`.
 - Restrict workflow execution to the default branch and the `npm` Environment.
+- Keep prereleases on `next`; do not leave a new package's automatically created `latest` tag on a
+  beta version.
 - Revoke the token only after React beta, registry consumers and `legacy` finalization complete.
 - Never use this workflow for stable versions; stable remains blocked by device-smoke evidence.
 

--- a/scripts/bootstrap-beta-workflow.test.ts
+++ b/scripts/bootstrap-beta-workflow.test.ts
@@ -83,4 +83,26 @@ describe('bootstrap npm beta workflow', () => {
     expect(reactVerification).toBeGreaterThan(-1)
     expect(legacyTag).toBeGreaterThan(reactVerification)
   })
+
+  it('checks exact registry versions and retries propagation after publishing', async () => {
+    const workflow = await readFile(workflowPath, 'utf8')
+
+    expect(workflow).toContain(
+      'https://registry.npmjs.org/@trsoliu%2faudio-core/1.0.0-beta.1',
+    )
+    expect(workflow).toContain(
+      'https://registry.npmjs.org/vue-audio-native/1.0.0-beta.1',
+    )
+    expect(workflow.match(/for attempt in \{1\.\.12\}/g)?.length).toBe(2)
+    expect(workflow.match(/sleep 5/g)?.length).toBe(2)
+  })
+
+  it('does not leave the new core beta on the latest dist-tag', async () => {
+    const workflow = await readFile(workflowPath, 'utf8')
+
+    expect(workflow).toContain(
+      'npm dist-tag rm @trsoliu/audio-core latest --registry=https://registry.npmjs.org',
+    )
+    expect(workflow).toContain("'^latest: 1\\.0\\.0-beta\\.1$'")
+  })
 })


### PR DESCRIPTION
## Summary

- recover safely after the core beta published successfully but the npm package index briefly returned 404
- use exact version endpoints with bounded propagation retries for core and Vue
- keep prereleases on next by removing latest only when it points exactly at the new core beta
- verify dist-tags through the dedicated npm dist-tag endpoint and document the behavior in ADR 0003

## Incident evidence

Run 30509935404 published @trsoliu/audio-core@1.0.0-beta.1 with signed provenance, then failed on its immediate npm view verification. The exact version endpoint confirms the published tarball and attestation.

## Verification

All release gates passed locally, including 8 workflow contract tests, Silen audit/eval, package validation, and Playwright 25/25. Secret and local-path scans found no matches.