### PR TITLE
fix: accept npm first-version latest tag

### DIFF
--- a/.github/workflows/bootstrap-beta.yml
+++ b/.github/workflows/bootstrap-beta.yml
@@ -105,9 +105,7 @@ jobs:
         run: |
           npm dist-tag add @trsoliu/audio-core@1.0.0-beta.1 next --registry=https://registry.npmjs.org
           npm dist-tag add vue-audio-native@1.0.0-beta.1 next --registry=https://registry.npmjs.org
-          if npm dist-tag ls @trsoliu/audio-core --registry=https://registry.npmjs.org | grep --quiet '^latest: 1\.0\.0-beta\.1$'; then
-            npm dist-tag rm @trsoliu/audio-core latest --registry=https://registry.npmjs.org
-          fi
+          echo 'npm requires a latest tag while a package has no stable version; next remains the documented prerelease channel.'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_BOOTSTRAP_TOKEN }}
       - name: Show published dist-tags

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ package changelogs are managed by Changesets.
   environment secret before permanent migration to OIDC Trusted Publishing.
 - Included hidden Silen output in the GitHub Pages artifact so the public Agent Contract under
   `.well-known/silen` is deployed with the documentation site.
-- Made the beta bootstrap tolerate npm registry propagation delays and remove an automatically
-  created `latest` tag when it points at the new core prerelease.
+- Made the beta bootstrap tolerate npm registry propagation delays and the registry-required
+  `latest` alias on a new package that has no stable version; `next` remains the prerelease channel.
 
 ### Added
 

--- a/docs/adr/0003-bootstrap-npm-publishing.md
+++ b/docs/adr/0003-bootstrap-npm-publishing.md
@@ -25,9 +25,11 @@ only to manual bootstrap publishing steps on the default branch.
 The Vue bootstrap workflow runs the complete release gates, publishes core before Vue with the
 `next` tag and is safe to rerun after a partial publication. Exact registry version endpoints and a
 bounded propagation retry prevent a successful first publish from being mistaken for a failure.
-For a new package, the workflow removes `latest` only when npm automatically points it at the beta.
-The React repository uses the same pattern only after installing the public core beta. After all
-three betas and clean registry consumers pass, a separate confirmed workflow mode sets
+npm requires a `latest` tag while a package has no stable version, so a brand-new package can expose
+the same first beta through both `latest` and the authoritative prerelease channel, `next`. The
+stable release will move `latest` to `1.0.0`; existing `vue-audio-native` keeps `latest` on 0.1.41.
+The React repository uses the same bootstrap pattern only after installing the public core beta.
+After all three betas and clean registry consumers pass, a separate confirmed workflow mode sets
 `vue-audio-native@0.1.41` to `legacy`.
 
 Immediately afterward, configure each package to trust its repository's `release.yml` workflow,
@@ -74,8 +76,8 @@ required npm package names, dist-tags or clean npm consumer verification.
 
 - Keep the expiry at one day and organization permissions at `No access`.
 - Restrict workflow execution to the default branch and the `npm` Environment.
-- Keep prereleases on `next`; do not leave a new package's automatically created `latest` tag on a
-  beta version.
+- Keep `next` as the documented prerelease channel. Accept npm's required `latest` alias only while
+  a new package has no stable version, then move `latest` to `1.0.0` at stable release.
 - Revoke the token only after React beta, registry consumers and `legacy` finalization complete.
 - Never use this workflow for stable versions; stable remains blocked by device-smoke evidence.
 

--- a/scripts/bootstrap-beta-workflow.test.ts
+++ b/scripts/bootstrap-beta-workflow.test.ts
@@ -97,12 +97,17 @@ describe('bootstrap npm beta workflow', () => {
     expect(workflow.match(/sleep 5/g)?.length).toBe(2)
   })
 
-  it('does not leave the new core beta on the latest dist-tag', async () => {
+  it('keeps next authoritative without trying to remove the first-version latest tag', async () => {
     const workflow = await readFile(workflowPath, 'utf8')
 
-    expect(workflow).toContain(
+    expect(workflow).not.toContain(
       'npm dist-tag rm @trsoliu/audio-core latest --registry=https://registry.npmjs.org',
     )
-    expect(workflow).toContain("'^latest: 1\\.0\\.0-beta\\.1$'")
+    expect(workflow).toContain(
+      'npm requires a latest tag while a package has no stable version',
+    )
+    expect(workflow).toContain(
+      'npm dist-tag add @trsoliu/audio-core@1.0.0-beta.1 next',
+    )
   })
 })


### PR DESCRIPTION
## Summary
- keep `next` as the documented prerelease channel
- accept npm's required `latest` alias while audio-core has no stable version
- prevent a successful bootstrap publish from failing during tag normalization
- record the registry constraint in ADR 0003 and the changelog

## Verification
- `pnpm test:release` (red before workflow change, green after)
- complete repository release gate chain
- 25/25 Playwright tests
- Prettier and `git diff --check`
- registry confirms core and Vue beta tarballs