### PR TITLE
ci: enforce stable device smoke gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,13 +17,14 @@ jobs:
   release:
     if: github.repository == 'trsoliu/vue-audio-native'
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     environment: npm
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
@@ -31,16 +32,28 @@ jobs:
       - run: npm install --global npm@12.0.1
       - run: pnpm install --frozen-lockfile
       - run: pnpm security:audit
-      - run: pnpm lint && pnpm typecheck && pnpm test:coverage
-      - run: pnpm build && pnpm test:pack
+      - run: pnpm lint
+      - run: pnpm typecheck
+      - run: pnpm test:coverage
+      - run: pnpm build
+      - run: pnpm docs:build
+      - run: pnpm docs:index
+      - run: pnpm docs:audit
+      - run: pnpm docs:eval
+      - run: pnpm test:pack
+      - run: pnpm exec playwright install --with-deps chromium firefox webkit
+      - run: pnpm test:e2e
       - name: Create or update the release PR
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1
         with:
           version: pnpm version-packages
           title: 'chore: release packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Verify stable device-smoke evidence
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        run: pnpm release:verify-devices
       - name: Publish with npm Trusted Publishing
         if: steps.changesets.outputs.hasChangesets == 'false'
         run: pnpm release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ package changelogs are managed by Changesets.
   `.well-known/silen` is deployed with the documentation site.
 - Made the beta bootstrap tolerate npm registry propagation delays and the registry-required
   `latest` alias on a new package that has no stable version; `next` remains the prerelease channel.
+- Added a machine-enforced stable-release device gate and pinned every action in the privileged
+  Trusted Publishing workflow to an immutable commit.
 
 ### Added
 

--- a/docs/device-smoke.md
+++ b/docs/device-smoke.md
@@ -16,3 +16,6 @@ WKWebView、Android WebView、HarmonyOS WebView 与 HarmonyOS NEXT ArkWeb 的带
 | HarmonyOS NEXT ArkWeb  | 播放、跳转、能力探测、宿主 Bridge 回调、销毁清理             | 待验证 |
 
 每次验证必须记录设备与系统版本、浏览器或 WebView 引擎版本、宿主版本、commit SHA、结果和证据文件位置。任何必需环境无法取得时，只能发布 npm `next` 预发行标签，不能发布稳定版。
+
+发布工作流会解析上表；只有四个状态单元格都精确写为 `通过` 时，Trusted Publishing
+步骤才会执行。填写 `通过` 的同时必须在本页追加对应的日期、版本、commit SHA 与证据位置。

--- a/docs/wiki/release.mdx
+++ b/docs/wiki/release.mdx
@@ -46,4 +46,6 @@ commit SHA 与对应 CI URL。
 ## 稳定发布
 
 稳定版通过 GitHub Actions Trusted Publishing、OIDC 与 provenance 发布。工作流不保存长期
-npm token。任何待处理的[真机冒烟](../device-smoke/)都会阻止 stable Changesets PR 合并。
+npm token。`pnpm release:verify-devices` 会在 publish 之前解析[真机冒烟](../device-smoke/)
+的四个必需环境；任一状态不是精确的 `通过` 都会在 Actions 中阻断稳定发布，但不会阻止
+Changesets 创建或更新 release PR。

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "test:release": "vitest run --config vitest.release.config.ts",
     "changeset": "changeset",
     "version-packages": "changeset version",
-    "release": "changeset publish"
+    "release": "changeset publish",
+    "release:verify-devices": "tsx scripts/device-smoke-gate.ts docs/device-smoke.md"
   },
   "devDependencies": {
     "@aicode-nexus/silen": "0.4.0",

--- a/scripts/device-smoke-gate.test.ts
+++ b/scripts/device-smoke-gate.test.ts
@@ -1,0 +1,54 @@
+import { execFile } from 'node:child_process'
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { promisify } from 'node:util'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  evaluateDeviceSmoke,
+  requiredDeviceEnvironments,
+} from './device-smoke-gate'
+
+const execute = promisify(execFile)
+
+describe('stable device-smoke gate', () => {
+  it('reports every currently pending required environment', async () => {
+    const markdown = await readFile(
+      resolve(import.meta.dirname, '../docs/device-smoke.md'),
+      'utf8',
+    )
+
+    expect(evaluateDeviceSmoke(markdown)).toEqual(requiredDeviceEnvironments)
+  })
+
+  it('accepts only a complete table with exact passing statuses', () => {
+    const rows = requiredDeviceEnvironments
+      .map((environment) => `| ${environment} | evidence | 通过 |`)
+      .join('\n')
+
+    expect(evaluateDeviceSmoke(rows)).toEqual([])
+    expect(evaluateDeviceSmoke(rows.replace('通过', '待验证'))).toEqual([
+      requiredDeviceEnvironments[0],
+    ])
+  })
+
+  it('runs as a CLI and reports the pending environments', async () => {
+    await expect(
+      execute(
+        process.execPath,
+        [
+          '--import',
+          'tsx',
+          resolve(import.meta.dirname, 'device-smoke-gate.ts'),
+          'docs/device-smoke.md',
+        ],
+        { cwd: resolve(import.meta.dirname, '..') },
+      ),
+    ).rejects.toMatchObject({
+      stderr: expect.stringContaining(
+        'Stable release blocked by device-smoke evidence',
+      ),
+    })
+  })
+})

--- a/scripts/device-smoke-gate.ts
+++ b/scripts/device-smoke-gate.ts
@@ -1,0 +1,60 @@
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+export const requiredDeviceEnvironments = [
+  'iOS 15.6+ WKWebView',
+  'Android 8+ WebView 96+',
+  'HarmonyOS 3/4 WebView',
+  'HarmonyOS NEXT ArkWeb',
+] as const
+
+function tableRows(markdown: string): Map<string, string> {
+  const rows = new Map<string, string>()
+
+  for (const line of markdown.split(/\r?\n/)) {
+    if (!line.trim().startsWith('|')) continue
+    const cells = line
+      .split('|')
+      .slice(1, -1)
+      .map((cell) => cell.trim())
+    if (cells.length < 3) continue
+    const environment = cells[0]
+    const status = cells.at(-1)
+    if (environment && status) rows.set(environment, status)
+  }
+
+  return rows
+}
+
+export function evaluateDeviceSmoke(markdown: string): string[] {
+  const rows = tableRows(markdown)
+  return requiredDeviceEnvironments.filter(
+    (environment) => rows.get(environment) !== '通过',
+  )
+}
+
+export async function verifyDeviceSmoke(
+  filePath = 'docs/device-smoke.md',
+): Promise<void> {
+  const absolutePath = resolve(process.cwd(), filePath)
+  const blocked = evaluateDeviceSmoke(await readFile(absolutePath, 'utf8'))
+  if (blocked.length > 0) {
+    throw new Error(
+      `Stable release blocked by device-smoke evidence: ${blocked.join(', ')}`,
+    )
+  }
+  console.log(
+    'Stable release device-smoke gate passed for all required environments.',
+  )
+}
+
+const invokedModule = process.argv[1]
+  ? pathToFileURL(resolve(process.argv[1])).href
+  : ''
+if (import.meta.url === invokedModule) {
+  void verifyDeviceSmoke(process.argv[2]).catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  })
+}

--- a/scripts/release-workflow.test.ts
+++ b/scripts/release-workflow.test.ts
@@ -1,0 +1,33 @@
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const repositoryRoot = resolve(import.meta.dirname, '..')
+const workflowPath = resolve(repositoryRoot, '.github/workflows/release.yml')
+
+describe('stable npm release workflow', () => {
+  it('runs the device gate after versioning and before publication', async () => {
+    const workflow = await readFile(workflowPath, 'utf8')
+    const changesets = workflow.indexOf('id: changesets')
+    const deviceGate = workflow.indexOf('pnpm release:verify-devices')
+    const publish = workflow.indexOf('\n        run: pnpm release\n')
+
+    expect(changesets).toBeGreaterThan(-1)
+    expect(deviceGate).toBeGreaterThan(changesets)
+    expect(publish).toBeGreaterThan(deviceGate)
+    expect(workflow).toContain(
+      "if: steps.changesets.outputs.hasChangesets == 'false'",
+    )
+  })
+
+  it('pins every release action to an immutable commit', async () => {
+    const workflow = await readFile(workflowPath, 'utf8')
+    const actionReferences = [...workflow.matchAll(/uses:\s+[^@\s]+@([^\s]+)/g)]
+
+    expect(actionReferences.length).toBeGreaterThan(0)
+    for (const reference of actionReferences) {
+      expect(reference[1]).toMatch(/^[a-f0-9]{40}$/)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- parse all four required WebView rows before stable npm publication
- keep Changesets release PR creation available while evidence is pending
- pin every privileged release Action to an immutable commit
- run the full docs and cross-browser gates in Trusted Publishing

## Verification
- release tests failed before implementation and pass after
- `pnpm release:verify-devices` currently blocks all four pending platforms
- complete repository release gate chain passed
- 25/25 Playwright tests
- Prettier and diff checks passed