### PR TITLE
fix: publish self-contained Vue declarations

### DIFF
--- a/.changeset/safe-vue-declarations.md
+++ b/.changeset/safe-vue-declarations.md
@@ -1,0 +1,6 @@
+---
+'vue-audio-native': patch
+---
+
+Keep the published Vue component declarations self-contained so strict TypeScript consumers can
+resolve props, events, slots and exposed controls without private Vue compiler symbols.

--- a/.github/workflows/bootstrap-beta.yml
+++ b/.github/workflows/bootstrap-beta.yml
@@ -11,7 +11,7 @@ on:
           - publish-vue-beta
           - finalize-legacy
       confirm:
-        description: 'Type publish-beta.1 or finalize-legacy for the selected mode'
+        description: 'Type publish-beta.2 or finalize-legacy for the selected mode'
         required: true
         type: string
 
@@ -29,7 +29,7 @@ jobs:
       github.repository == 'trsoliu/vue-audio-native' &&
       github.ref == 'refs/heads/master' &&
       inputs.mode == 'publish-vue-beta' &&
-      inputs.confirm == 'publish-beta.1'
+      inputs.confirm == 'publish-beta.2'
     runs-on: ubuntu-latest
     timeout-minutes: 40
     environment: npm
@@ -81,19 +81,19 @@ jobs:
       - name: Publish Vue beta when absent
         working-directory: packages/vue-audio-native
         run: |
-          registry_url='https://registry.npmjs.org/vue-audio-native/1.0.0-beta.1'
+          registry_url='https://registry.npmjs.org/vue-audio-native/1.0.0-beta.2'
           if curl --fail --silent --show-error --output /dev/null "$registry_url"; then
-            echo 'vue-audio-native@1.0.0-beta.1 is already published; skipping.'
+            echo 'vue-audio-native@1.0.0-beta.2 is already published; skipping.'
           else
             npm publish --tag next --access public --registry=https://registry.npmjs.org
           fi
           for attempt in {1..12}; do
             if curl --fail --silent --show-error --output /dev/null "$registry_url"; then
-              echo 'vue-audio-native@1.0.0-beta.1 is visible on the registry.'
+              echo 'vue-audio-native@1.0.0-beta.2 is visible on the registry.'
               break
             fi
             if [[ "$attempt" == 12 ]]; then
-              echo '::error::vue-audio-native@1.0.0-beta.1 was not visible after 12 checks.'
+              echo '::error::vue-audio-native@1.0.0-beta.2 was not visible after 12 checks.'
               exit 1
             fi
             sleep 5
@@ -104,7 +104,7 @@ jobs:
       - name: Normalize prerelease dist-tags
         run: |
           npm dist-tag add @trsoliu/audio-core@1.0.0-beta.1 next --registry=https://registry.npmjs.org
-          npm dist-tag add vue-audio-native@1.0.0-beta.1 next --registry=https://registry.npmjs.org
+          npm dist-tag add vue-audio-native@1.0.0-beta.2 next --registry=https://registry.npmjs.org
           echo 'npm requires a latest tag while a package has no stable version; next remains the documented prerelease channel.'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_BOOTSTRAP_TOKEN }}
@@ -132,7 +132,7 @@ jobs:
       - name: Verify every beta is public before changing compatibility tags
         run: |
           npm view @trsoliu/audio-core@1.0.0-beta.1 version --registry=https://registry.npmjs.org
-          npm view vue-audio-native@1.0.0-beta.1 version --registry=https://registry.npmjs.org
+          npm view vue-audio-native@1.0.0-beta.2 version --registry=https://registry.npmjs.org
           npm view react-audio-native@1.0.0-beta.1 version --registry=https://registry.npmjs.org
       - name: Preserve the Vue 2 release line
         run: npm dist-tag add vue-audio-native@0.1.41 legacy --registry=https://registry.npmjs.org

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ package changelogs are managed by Changesets.
   `latest` alias on a new package that has no stable version; `next` remains the prerelease channel.
 - Added a machine-enforced stable-release device gate and pinned every action in the privileged
   Trusted Publishing workflow to an immutable commit.
+- Fixed the published Vue declaration bundle so strict TypeScript consumers can resolve component
+  props, events, slots and exposed controls without private `__VLS_*` compiler symbols.
 
 ### Added
 
@@ -37,7 +39,9 @@ package changelogs are managed by Changesets.
 
 ### Release boundary
 
-- Source versions are prepared as `1.0.0-beta.1`; no npm publication is claimed by this file.
+- `@trsoliu/audio-core@1.0.0-beta.1`, `vue-audio-native@1.0.0-beta.1` and
+  `react-audio-native@1.0.0-beta.1` are published; the Vue declaration correction is prepared as
+  `vue-audio-native@1.0.0-beta.2`.
 - Stable `1.0.0` remains blocked until iOS WKWebView, Android WebView and HarmonyOS ArkWeb smoke
   evidence is complete.
 

--- a/docs/adr/0003-bootstrap-npm-publishing.md
+++ b/docs/adr/0003-bootstrap-npm-publishing.md
@@ -83,7 +83,8 @@ required npm package names, dist-tags or clean npm consumer verification.
 
 ## Follow-up actions
 
-- [ ] Publish the core, Vue and React `1.0.0-beta.1` versions.
+- [x] Publish the core, Vue and React `1.0.0-beta.1` versions.
+- [ ] Publish `vue-audio-native@1.0.0-beta.2` with the strict declaration-consumer fix.
 - [ ] Complete clean Vite, Nuxt, React and Next registry-consumer verification.
 - [ ] Set the Vue 2 `legacy` tag only after the beta verification succeeds.
 - [ ] Configure Trusted Publishers for all three packages.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -15,8 +15,8 @@ Vue Audio Native 1.0 不只是一个播放器组件。它把浏览器媒体状�
 
 ## 当前发布状态
 
-- 源码目标版本：`@trsoliu/audio-core@1.0.0-beta.1` 与
-  `vue-audio-native@1.0.0-beta.1`。
+- 当前候选版本：`@trsoliu/audio-core@1.0.0-beta.1` 与
+  `vue-audio-native@1.0.0-beta.2`；Vue beta.2 修复严格 TypeScript 消费者的声明解析。
 - Vue 2 继续使用 `vue-audio-native@0.1.41`，稳定发布前会设置 `legacy` 标签。
 - 稳定 `1.0.0` 仍由 iOS WKWebView、Android WebView 和 HarmonyOS ArkWeb 的
   [真机冒烟记录](./device-smoke/)控制。

--- a/docs/wiki/release.mdx
+++ b/docs/wiki/release.mdx
@@ -10,7 +10,8 @@ description: beta、stable、npm dist-tag、Trusted Publishing 与干净消费�
 1. 两个仓库完成 lint、类型、覆盖率、build、Silen audit/eval、pack 和浏览器 E2E。
 2. 核验 npm 身份与 `vue-audio-native` 原包维护权限；权限缺失时停止，不改包名。
 3. 先发布 `@trsoliu/audio-core@1.0.0-beta.1 --tag next`。
-4. 再发布 `vue-audio-native@1.0.0-beta.1 --tag next`，随后让 React 仓库从 registry 安装。
+4. Vue 初始 beta.1 发布后发现严格 TypeScript 声明回归，因此发布
+   `vue-audio-native@1.0.0-beta.2 --tag next`，随后让 React 仓库从 registry 安装。
 5. 发布 React beta，并在完全干净的 Vite、Nuxt、React 和 Next 消费者中验证 registry 包。
 6. 三个 beta 与干净消费者回归全部通过后，将 `vue-audio-native@0.1.41` 设置为 `legacy`。
 7. 真机证据完成前保持 beta；完成后才发布稳定 1.0。
@@ -25,7 +26,8 @@ description: beta、stable、npm dist-tag、Trusted Publishing 与干净消费�
 2. 将 token 保存到 Vue 和 React 两个仓库的 GitHub `npm` Environment Secret
    `NPM_BOOTSTRAP_TOKEN`；不写入本机 `.npmrc`、代码、日志或 PR。
 3. 从 Vue 仓库 `master` 手动触发 `Bootstrap npm beta`，mode 选择 `publish-vue-beta`、确认值
-   填写 `publish-beta.1`。工作流会先运行完整门禁，再按 core → Vue 顺序发布 `next`。
+   填写 `publish-beta.2`。工作流会先运行完整门禁，确认 core beta.1 后发布 Vue beta.2 到
+   `next`。
 4. React 仓库改用 registry core、通过门禁并发布 React beta 后，完成四类干净消费者回归。
 5. 再次触发 Vue `Bootstrap npm beta`，mode 选择 `finalize-legacy`、确认值填写
    `finalize-legacy`。工作流只有在三个 beta 都可查询时才会设置 `legacy`。

--- a/packages/vue-audio-native/package.json
+++ b/packages/vue-audio-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-audio-native",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "Accessible Vue 3 audio player for modern browsers and WebViews.",
   "type": "module",
   "license": "MIT",

--- a/packages/vue-audio-native/scripts/check-pack.ts
+++ b/packages/vue-audio-native/scripts/check-pack.ts
@@ -7,6 +7,30 @@ import { gzipSync } from 'node:zlib'
 
 const execute = promisify(execFile)
 const packageRoot = resolve(import.meta.dirname, '..')
+
+await execute(
+  'pnpm',
+  [
+    'exec',
+    'tsc',
+    '--ignoreConfig',
+    '--noEmit',
+    '--skipLibCheck',
+    'false',
+    '--strict',
+    '--module',
+    'ESNext',
+    '--moduleResolution',
+    'Bundler',
+    '--target',
+    'ES2019',
+    '--lib',
+    'ES2023,DOM,DOM.Iterable',
+    'dist/index.d.ts',
+  ],
+  { cwd: packageRoot },
+)
+
 const { stdout } = await execute(
   'npm',
   ['pack', '--dry-run', '--json'],

--- a/packages/vue-audio-native/src/index.ts
+++ b/packages/vue-audio-native/src/index.ts
@@ -1,10 +1,67 @@
 import './styles.css'
 
-import type { App, Plugin } from 'vue'
+import type {
+  AudioPlayerError,
+  AudioPlayerHandle,
+  AudioSnapshot,
+  AudioTrack,
+} from '@trsoliu/audio-core'
+import type {
+  App,
+  ComponentOptionsMixin,
+  DefineComponent,
+  Plugin,
+} from 'vue'
 
-import VueAudioNative from './VueAudioNative.vue'
+import VueAudioNativeSfc from './VueAudioNative.vue'
+import type { VueAudioNativeProps } from './types'
 
-export { VueAudioNative }
+type EmptyRecord = Record<string, never>
+
+type VueAudioNativeEmits = {
+  ended: (snapshot: AudioSnapshot) => void
+  error: (error: AudioPlayerError) => void
+  'on-audioId': (id: string) => void
+  'on-change': (playing: boolean) => void
+  'on-metadata': (event: Event) => void
+  'on-timeupdate': (currentTime: number) => void
+  pause: (snapshot: AudioSnapshot) => void
+  play: (snapshot: AudioSnapshot) => void
+  ready: (snapshot: AudioSnapshot) => void
+  statechange: (snapshot: AudioSnapshot) => void
+  timeupdate: (currentTime: number, snapshot: AudioSnapshot) => void
+  trackchange: (track: AudioTrack | null, trackIndex: number) => void
+}
+
+interface VueAudioNativeSlots {
+  'after-controls'?: (props: {
+    controls: AudioPlayerHandle
+    snapshot: AudioSnapshot
+  }) => unknown
+  artwork?: (props: { track: AudioTrack }) => unknown
+  'before-controls'?: (props: {
+    controls: AudioPlayerHandle
+    snapshot: AudioSnapshot
+  }) => unknown
+  slotTip?: (props: EmptyRecord) => unknown
+  tip?: (props: EmptyRecord) => unknown
+}
+
+type VueAudioNativeComponent = DefineComponent<
+  VueAudioNativeProps,
+  AudioPlayerHandle,
+  EmptyRecord,
+  EmptyRecord,
+  EmptyRecord,
+  ComponentOptionsMixin,
+  ComponentOptionsMixin,
+  VueAudioNativeEmits,
+  keyof VueAudioNativeEmits & string
+> &
+  (new () => { $slots: VueAudioNativeSlots })
+
+export const VueAudioNative =
+  VueAudioNativeSfc as unknown as VueAudioNativeComponent
 export const AudioPlayer = VueAudioNative
 export { useAudioPlayer } from './use-audio-player'
 export type {

--- a/scripts/bootstrap-beta-workflow.test.ts
+++ b/scripts/bootstrap-beta-workflow.test.ts
@@ -17,7 +17,7 @@ describe('bootstrap npm beta workflow', () => {
     expect(workflow).not.toMatch(/^\s+push:/m)
     expect(workflow).toContain("github.ref == 'refs/heads/master'")
     expect(workflow).toContain("inputs.mode == 'publish-vue-beta'")
-    expect(workflow).toContain("inputs.confirm == 'publish-beta.1'")
+    expect(workflow).toContain("inputs.confirm == 'publish-beta.2'")
     expect(workflow).toContain("inputs.mode == 'finalize-legacy'")
     expect(workflow).toContain("inputs.confirm == 'finalize-legacy'")
     expect(workflow).toContain('environment: npm')
@@ -91,7 +91,7 @@ describe('bootstrap npm beta workflow', () => {
       'https://registry.npmjs.org/@trsoliu%2faudio-core/1.0.0-beta.1',
     )
     expect(workflow).toContain(
-      'https://registry.npmjs.org/vue-audio-native/1.0.0-beta.1',
+      'https://registry.npmjs.org/vue-audio-native/1.0.0-beta.2',
     )
     expect(workflow.match(/for attempt in \{1\.\.12\}/g)?.length).toBe(2)
     expect(workflow.match(/sleep 5/g)?.length).toBe(2)
@@ -108,6 +108,9 @@ describe('bootstrap npm beta workflow', () => {
     )
     expect(workflow).toContain(
       'npm dist-tag add @trsoliu/audio-core@1.0.0-beta.1 next',
+    )
+    expect(workflow).toContain(
+      'npm dist-tag add vue-audio-native@1.0.0-beta.2 next',
     )
   })
 })


### PR DESCRIPTION
## Summary
- replace compiler-private Vue SFC declaration leakage with an explicit public component facade
- compile the shipped declaration bundle with strict TypeScript during every pack gate
- prepare `vue-audio-native@1.0.0-beta.2` and update the guarded bootstrap workflow/docs

## Root cause
`vite-plugin-dts` declaration bundling uses API Extractor, which strips the `declare var __VLS_*` slot bindings emitted by Vue language tools (qmhc/unplugin-dts#416). The raw SFC declaration was valid, but the bundled npm declaration was not.

## Verification
- full repository release gate passed locally
- strict TypeScript declaration compilation passed with `skipLibCheck: false`
- local packed tarball installed and built in a standalone Vite Vue project
- Playwright: 25/25
