### PR TITLE
fix: sync lockfile during release versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ package changelogs are managed by Changesets.
   props, events, slots and exposed controls without private `__VLS_*` compiler symbols.
 - Retired the short-lived token bootstrap workflow after beta publication, clean registry-consumer
   verification and Vue 2 `legacy` tag finalization; permanent releases use OIDC only.
+- Fixed Changesets release versioning to refresh the pnpm lockfile after coordinated core and Vue
+  package version updates, keeping generated release PRs installable with `--frozen-lockfile`.
 
 ### Added
 

--- a/docs/wiki/release.mdx
+++ b/docs/wiki/release.mdx
@@ -49,3 +49,7 @@ commit SHA 与对应 CI URL。
 npm token。`pnpm release:verify-devices` 会在 publish 之前解析[真机冒烟](../device-smoke/)
 的四个必需环境；任一状态不是精确的 `通过` 都会在 Actions 中阻断稳定发布，但不会阻止
 Changesets 创建或更新 release PR。
+
+Vue 仓库采用 core 与组件协调版本。`pnpm version-packages` 在 Changesets 更新 manifests 后
+立即以 `--lockfile-only --ignore-scripts` 刷新 pnpm lockfile，保证生成的 release PR 仍可通过
+CI 的 `pnpm install --frozen-lockfile`，且版本阶段不会执行依赖生命周期脚本。

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:pack": "turbo run test:pack",
     "test:release": "vitest run --config vitest.release.config.ts",
     "changeset": "changeset",
-    "version-packages": "changeset version",
+    "version-packages": "changeset version && pnpm install --lockfile-only --ignore-scripts",
     "release": "changeset publish",
     "release:verify-devices": "tsx scripts/device-smoke-gate.ts docs/device-smoke.md"
   },

--- a/scripts/release-workflow.test.ts
+++ b/scripts/release-workflow.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest'
 
 const repositoryRoot = resolve(import.meta.dirname, '..')
 const workflowPath = resolve(repositoryRoot, '.github/workflows/release.yml')
+const packagePath = resolve(repositoryRoot, 'package.json')
 
 describe('stable npm release workflow', () => {
   it('runs the device gate after versioning and before publication', async () => {
@@ -42,5 +43,16 @@ describe('stable npm release workflow', () => {
 
     expect(workflows.join('\n')).not.toContain('NPM_BOOTSTRAP_TOKEN')
     expect(await readFile(workflowPath, 'utf8')).toContain('id-token: write')
+  })
+
+  it('refreshes the workspace lockfile after Changesets updates internal versions', async () => {
+    const packageJson = JSON.parse(await readFile(packagePath, 'utf8')) as {
+      scripts?: Record<string, string>
+    }
+    const versionCommand = packageJson.scripts?.['version-packages']
+
+    expect(versionCommand).toContain('changeset version')
+    expect(versionCommand).toContain('pnpm install --lockfile-only')
+    expect(versionCommand).toContain('--ignore-scripts')
   })
 })


### PR DESCRIPTION
## Summary

- refresh `pnpm-lock.yaml` after Changesets coordinates core and Vue stable versions
- keep lifecycle scripts disabled during release versioning
- add a regression test and document the frozen-lockfile contract

## Root cause

The generated stable release PR updated `vue-audio-native` to depend on `@trsoliu/audio-core@1.0.0`, but the lockfile importer still declared `1.0.0-beta.1`, so both CI jobs failed at `pnpm install --frozen-lockfile`.

## Verification

- regression observed failing before implementation
- isolated `pnpm version-packages` simulation produced core/Vue/internal dependency `1.0.0` and passed frozen-lockfile validation
- full local release gates passed
- `pnpm test:e2e` (25/25)