### PR TITLE
docs: finalize npm trusted publishing records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ package changelogs are managed by Changesets.
   props, events, slots and exposed controls without private `__VLS_*` compiler symbols.
 - Retired the short-lived token bootstrap workflow after beta publication, clean registry-consumer
   verification and Vue 2 `legacy` tag finalization; permanent releases use OIDC only.
+- Configured npm Trusted Publishers for core, Vue and React against their exact `release.yml`
+  workflows and protected `npm` environments.
 - Fixed Changesets release versioning to refresh the pnpm lockfile after coordinated core and Vue
   package version updates, keeping generated release PRs installable with `--frozen-lockfile`.
 

--- a/docs/adr/0003-bootstrap-npm-publishing.md
+++ b/docs/adr/0003-bootstrap-npm-publishing.md
@@ -18,7 +18,9 @@ the repositories and avoid weakening the stable-release device gate.
 
 ## Decision
 
-Use a one-day npm Granular Access Token only for the first beta publications. Store it as the
+Use a bounded npm Granular Access Token only for the first beta publications. The operator selected
+a 90-day expiry ceiling on 2026-07-30, while the operational plan still requires revocation as soon
+as the OIDC cutover is verified rather than relying on that expiry. Store it as the
 `NPM_BOOTSTRAP_TOKEN` secret in each repository's protected `npm` GitHub Environment and expose it
 only to manual bootstrap publishing steps on the default branch.
 
@@ -72,12 +74,13 @@ required npm package names, dist-tags or clean npm consumer verification.
 - The temporary token must initially cover all user packages so it can create both scoped and
   unscoped names.
 - Two repository secrets must be created and then removed manually.
-- The token has bypass-2FA capability for at most one day, creating a short but non-zero exposure
-  window.
+- The token has bypass-2FA capability until it is revoked, with 2026-10-28 as its configured expiry
+  backstop, creating a short but non-zero bootstrap exposure window.
 
 ### Risk mitigation
 
-- Keep the expiry at one day and organization permissions at `No access`.
+- Keep organization permissions at `No access`, remove repository secrets immediately after the
+  bootstrap and revoke the token as soon as all OIDC bindings are verified.
 - Restrict workflow execution to the default branch and the `npm` Environment.
 - Keep `next` as the documented prerelease channel. Accept npm's required `latest` alias only while
   a new package has no stable version, then move `latest` to `1.0.0` at stable release.
@@ -90,9 +93,9 @@ required npm package names, dist-tags or clean npm consumer verification.
 - [x] Publish `vue-audio-native@1.0.0-beta.2` with the strict declaration-consumer fix.
 - [x] Complete clean Vite, Nuxt, React and Next registry-consumer verification.
 - [x] Set the Vue 2 `legacy` tag only after the beta verification succeeds.
-- [ ] Configure Trusted Publishers for all three packages.
+- [x] Configure Trusted Publishers for all three packages.
 - [x] Delete both GitHub bootstrap secrets and retire the temporary workflow.
-- [ ] Revoke the one-day bootstrap token on npm.
+- [ ] Revoke the bootstrap token on npm.
 
 ## References
 

--- a/docs/adr/0003-bootstrap-npm-publishing.md
+++ b/docs/adr/0003-bootstrap-npm-publishing.md
@@ -1,6 +1,6 @@
 # ADR 0003: Bootstrap new npm packages with a short-lived token before OIDC
 
-- Status: accepted; bootstrap completed
+- Status: accepted; bootstrap completed; token retained until expiry
 - Date: 2026-07-30
 - Decider: trsoliu
 - Owner: trsoliu
@@ -19,8 +19,8 @@ the repositories and avoid weakening the stable-release device gate.
 ## Decision
 
 Use a bounded npm Granular Access Token only for the first beta publications. The operator selected
-a 90-day expiry ceiling on 2026-07-30, while the operational plan still requires revocation as soon
-as the OIDC cutover is verified rather than relying on that expiry. Store it as the
+a 90-day expiry ceiling on 2026-07-30 and, after verifying the OIDC cutover, elected to retain the
+disconnected token until its 2026-10-28 expiry. Store it as the
 `NPM_BOOTSTRAP_TOKEN` secret in each repository's protected `npm` GitHub Environment and expose it
 only to manual bootstrap publishing steps on the default branch.
 
@@ -34,9 +34,10 @@ The React repository uses the same bootstrap pattern only after installing the p
 After all three betas and clean registry consumers pass, a separate confirmed workflow mode sets
 `vue-audio-native@0.1.41` to `legacy`.
 
-Immediately afterward, configure each package to trust its repository's `release.yml` workflow,
-delete both GitHub secrets and revoke the token. Stable releases use OIDC Trusted Publishing and
-provenance only.
+Immediately afterward, configure each package to trust its repository's `release.yml` workflow and
+delete both GitHub secrets. The retained npm-account token must not be restored to a repository,
+workflow or local npm configuration. Stable releases use OIDC Trusted Publishing and provenance
+only.
 
 The temporary workflow is removed from the default branch after the beta and `legacy` sequence;
 its immutable Actions runs and Git history retain the audit trail.
@@ -79,12 +80,12 @@ required npm package names, dist-tags or clean npm consumer verification.
 
 ### Risk mitigation
 
-- Keep organization permissions at `No access`, remove repository secrets immediately after the
-  bootstrap and revoke the token as soon as all OIDC bindings are verified.
+- Keep organization permissions at `No access` and remove repository secrets immediately after the
+  bootstrap. The owner accepts the residual risk of retaining the disconnected token until expiry.
 - Restrict workflow execution to the default branch and the `npm` Environment.
 - Keep `next` as the documented prerelease channel. Accept npm's required `latest` alias only while
   a new package has no stable version, then move `latest` to `1.0.0` at stable release.
-- Revoke the token only after React beta, registry consumers and `legacy` finalization complete.
+- Do not use or reintroduce the retained token; manually revoke it if the accepted risk changes.
 - Never use this workflow for stable versions; stable remains blocked by device-smoke evidence.
 
 ## Follow-up actions
@@ -95,7 +96,8 @@ required npm package names, dist-tags or clean npm consumer verification.
 - [x] Set the Vue 2 `legacy` tag only after the beta verification succeeds.
 - [x] Configure Trusted Publishers for all three packages.
 - [x] Delete both GitHub bootstrap secrets and retire the temporary workflow.
-- [ ] Revoke the bootstrap token on npm.
+- [x] Record the owner's decision to retain the disconnected token until 2026-10-28 and confirm it
+  is absent from both GitHub Environments and all release workflows.
 
 ## References
 

--- a/docs/wiki/release.mdx
+++ b/docs/wiki/release.mdx
@@ -19,9 +19,11 @@ description: beta、stable、npm dist-tag、Trusted Publishing 与干净消费�
 ## 首次 beta 引导发布（已完成）
 
 新包尚不存在时，无法先在 npm 包设置页绑定 Trusted Publisher。首次 beta 曾使用受保护的
-手动工作流与一天有效期的 Granular Access Token 引导，完成顺序如下：
+手动工作流与设有 90 天到期上限的 Granular Access Token 引导；该期限只是失效兜底，迁移
+完成后必须立即撤销，不能把到期时间当作清理机制。完成顺序如下：
 
-1. 在 npm 网站创建有效期一天、仅用于引导的 Granular Access Token：Packages and scopes 设为
+1. 在 npm 网站创建仅用于引导的 Granular Access Token：有效期上限为 2026-10-28，
+   Packages and scopes 设为
    `Read and write`、选择 `All Packages`、开启 bypass 2FA，Organizations 设为 `No access`。
 2. 将 token 保存到 Vue 和 React 两个仓库的 GitHub `npm` Environment Secret
    `NPM_BOOTSTRAP_TOKEN`；不写入本机 `.npmrc`、代码、日志或 PR。
@@ -29,10 +31,12 @@ description: beta、stable、npm dist-tag、Trusted Publishing 与干净消费�
 4. React 仓库改用 registry core、通过门禁并发布 React beta 后，完成四类干净消费者回归。
 5. 三个 beta 都可查询且四类消费者通过后，将 Vue 2 的 0.1.41 设置为 `legacy`。
 6. 删除两个 GitHub Secret，并在 npm 网站撤销该 token。
-7. 为已创建的包绑定 `.github/workflows/release.yml`、GitHub `npm` Environment 与 `npm publish`
-   Trusted Publisher；后续发布只使用 OIDC。
+7. 为已创建的三个包绑定 `.github/workflows/release.yml`、GitHub `npm` Environment 与
+   `npm publish` Trusted Publisher；后续发布只使用 OIDC。Vue 仓库绑定
+   `@trsoliu/audio-core` 与 `vue-audio-native`，React 仓库绑定 `react-audio-native`。
 
-该引导工作流和仓库 Secret 已在完成后移除，不能再用于发布。三个发布包都通过
+三个 Trusted Publisher 已于 2026-07-30 配置并逐项核验；引导工作流和仓库 Secret 已移除，
+不能再用于发布。三个发布包都通过
 `publishConfig.registry` 固定到官方 npm registry，不受本机安装镜像配置影响；首次 beta
 保留 provenance，后续版本必须由 `.github/workflows/release.yml` 和 Trusted Publishing 的
 短期 OIDC 凭据发布。

--- a/docs/wiki/release.mdx
+++ b/docs/wiki/release.mdx
@@ -19,8 +19,9 @@ description: beta、stable、npm dist-tag、Trusted Publishing 与干净消费�
 ## 首次 beta 引导发布（已完成）
 
 新包尚不存在时，无法先在 npm 包设置页绑定 Trusted Publisher。首次 beta 曾使用受保护的
-手动工作流与设有 90 天到期上限的 Granular Access Token 引导；该期限只是失效兜底，迁移
-完成后必须立即撤销，不能把到期时间当作清理机制。完成顺序如下：
+手动工作流与设有 90 天到期上限的 Granular Access Token 引导。OIDC 迁移完成后，所有者
+决定保留这枚已与仓库断开的 token 至 2026-10-28；它不能重新进入 Secret、工作流或本机
+npm 配置。完成顺序如下：
 
 1. 在 npm 网站创建仅用于引导的 Granular Access Token：有效期上限为 2026-10-28，
    Packages and scopes 设为
@@ -30,13 +31,15 @@ description: beta、stable、npm dist-tag、Trusted Publishing 与干净消费�
 3. Vue 仓库先运行完整门禁并按 core → Vue 顺序发布，声明修复以 Vue beta.2 更新到 `next`。
 4. React 仓库改用 registry core、通过门禁并发布 React beta 后，完成四类干净消费者回归。
 5. 三个 beta 都可查询且四类消费者通过后，将 Vue 2 的 0.1.41 设置为 `legacy`。
-6. 删除两个 GitHub Secret，并在 npm 网站撤销该 token。
+6. 删除两个 GitHub Secret；根据所有者决定，npm 账户中的 token 保留至到期，但不再用于
+   项目发布。
 7. 为已创建的三个包绑定 `.github/workflows/release.yml`、GitHub `npm` Environment 与
    `npm publish` Trusted Publisher；后续发布只使用 OIDC。Vue 仓库绑定
    `@trsoliu/audio-core` 与 `vue-audio-native`，React 仓库绑定 `react-audio-native`。
 
 三个 Trusted Publisher 已于 2026-07-30 配置并逐项核验；引导工作流和仓库 Secret 已移除，
-不能再用于发布。三个发布包都通过
+两个 GitHub `npm` Environment 的 Secret 数量均为 0。保留的账户 token 不属于项目发布
+链路；后续只能由 Trusted Publisher 获取短期 OIDC 凭据。三个发布包都通过
 `publishConfig.registry` 固定到官方 npm registry，不受本机安装镜像配置影响；首次 beta
 保留 provenance，后续版本必须由 `.github/workflows/release.yml` 和 Trusted Publishing 的
 短期 OIDC 凭据发布。


### PR DESCRIPTION
## Summary\n- record verified npm Trusted Publisher bindings for core, Vue, and React\n- record the owner's decision to retain the disconnected bootstrap token until 2026-10-28\n- confirm the token remains absent from GitHub secrets and release workflows\n- keep stable device smoke explicitly pending\n\n## Verification\n- full local release gate suite passed\n- Silen build, index, audit, and eval passed after the retention record update\n- GitHub npm Environment secret count is zero\n- release workflows contain no NPM_BOOTSTRAP_TOKEN reference