### PR TITLE
Harden audio state and publish complete API docs

### DIFF
--- a/.changeset/clear-audio-api-docs.md
+++ b/.changeset/clear-audio-api-docs.md
@@ -1,0 +1,9 @@
+---
+'@trsoliu/audio-core': patch
+'vue-audio-native': patch
+---
+
+Publish complete npm API and Events references, including option defaults, callback payloads,
+snapshot states, structured errors, command behavior, Bridge events, and correct Vue headless ref
+usage. Keep volume and playback-rate state finite for invalid numeric input, and keep conflicting
+input warnings out of production builds.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ package changelogs are managed by Changesets.
 
 ## Unreleased
 
+- Expanded the Vue and audio-core API references with every public option, event payload, snapshot
+  state, error code, command, slot, Bridge event and npm README usage contract; also corrected the
+  headless Vue template ref example and clarified that low-level controller values come from
+  `@trsoliu/audio-core`.
+- Kept volume and playback-rate snapshots finite when integrations pass `NaN` or infinite values,
+  and limited conflicting-input migration warnings to development builds.
 - Fixed WebView Bridge teardown so removing an adapter happens before a simultaneous source switch.
 - Pinned publishable packages to the official npm registry so local mirror settings cannot redirect a release.
 - Added a manual, gated GitHub Actions bootstrap for the first npm beta using a short-lived

--- a/README.md
+++ b/README.md
@@ -19,6 +19,19 @@ fixtures/nuxt              Nuxt SSR 消费者构建验证
 docs                       Silen 文档站、项目地图与 AI 知识库
 ```
 
+## Public API
+
+- Vue 组件的完整 props、现代/兼容事件 payload、状态、错误、句柄、composable 和插槽见
+  [`docs/api`](docs/api/index.mdx)。
+- npm 上的 Vue 接入材料来自
+  [`packages/vue-audio-native/README.md`](packages/vue-audio-native/README.md)。
+- `@trsoliu/audio-core` 的 controller、snapshot 订阅和 Bridge Events 见
+  [`packages/audio-core/README.md`](packages/audio-core/README.md)。
+
+组件事件描述的是 `AudioSnapshot` 状态变化，并非原生 `<audio>` 事件的逐条透传。需要直接
+创建 controller 时请从 `@trsoliu/audio-core` 导入 `createAudioController()`；Vue 包只暴露
+组件、composable、适配层工具和共享类型。
+
 ## Development
 
 要求 Node.js 22.22.2 及以上、Corepack 和 pnpm 11.17.0。

--- a/docs/.silen/ai-evals.json
+++ b/docs/.silen/ai-evals.json
@@ -15,6 +15,18 @@
       "expected": { "route": "/migration-v1/" }
     },
     {
+      "id": "vue-event-payloads",
+      "query": "Vue ready play buffering timeupdate trackchange error 事件在什么时候触发 payload 是什么",
+      "lang": "zh-CN",
+      "expected": { "route": "/api/" }
+    },
+    {
+      "id": "core-bridge-events",
+      "query": "audio-core Bridge statechange trackchange error 的完整消息结构和解绑方式",
+      "lang": "zh-CN",
+      "expected": { "route": "/api/" }
+    },
+    {
       "id": "workspace-boundary",
       "query": "audio-core Vue adapter demo fixtures 的依赖边界和项目地图",
       "lang": "zh-CN",

--- a/docs/api/index.mdx
+++ b/docs/api/index.mdx
@@ -1,55 +1,376 @@
 ---
-title: 公共 API
-description: Vue 组件、composable、共享类型、事件、插槽与命令句柄。
+title: 公共 API 与事件
+description: Vue 组件、composable、共享状态、事件 payload、命令句柄与 audio-core 控制器的完整契约。
 ---
 
-# 公共 API
+# 公共 API 与事件
 
-## 导出
+Vue 组件和 `useAudioPlayer()` 都适配同一套 `@trsoliu/audio-core` 状态。组件事件不是
+原生 `<audio>` 事件的逐条转发，而是根据不可变 `AudioSnapshot` 的变化发出。业务代码应
+以事件 payload 或 composable 的 `snapshot` 为准，不要同时维护另一套播放状态。
 
-`vue-audio-native` 导出：
+## 导出边界
 
-- `VueAudioNative`，别名 `AudioPlayer`；
-- 默认插件，可通过 `app.use()` 注册；
-- `useAudioPlayer()`；
-- `createAudioController()`、能力检测和时间格式化工具；
-- `AudioTrack`、`AudioSnapshot`、`AudioPlayerError`、`AudioPlayerHandle`、
-`AudioPlayerBridge` 等公共类型。
+从 `vue-audio-native` 导入：
 
-Headless `useAudioPlayer()` 接受协议无关的 `bridge`；从响应式 options 中移除它会解绑旧
-宿主。直接使用 controller 时可传 `bridge: null` 完成同一操作。
+| 导出                                                                   | 类型         | 用途                                                              |
+| ---------------------------------------------------------------------- | ------------ | ----------------------------------------------------------------- |
+| `VueAudioNative`                                                       | value        | 推荐的 Vue 3 组件                                                 |
+| `AudioPlayer`                                                          | value        | `VueAudioNative` 的同一组件别名                                   |
+| default export                                                         | Vue `Plugin` | `app.use(VueAudioNative)`，注册 `VueAudioNative` 与 `AudioPlayer` |
+| `useAudioPlayer()`                                                     | function     | 无界面的响应式播放器 composable                                   |
+| `detectAudioCapabilities()`                                            | function     | 无 UA 的运行时能力检测                                            |
+| `formatMediaTime()`                                                    | function     | 把秒数格式化为 `mm:ss` 或 `hh:mm:ss`                              |
+| `VueAudioNativeProps`、`UseAudioPlayerOptions`、`UseAudioPlayerResult` | type         | Vue 适配层类型                                                    |
+| core 共享类型                                                          | type         | track、snapshot、error、Bridge、handle 等类型                     |
 
-## 现代 props
+完整 type-only 导出为：
 
-| prop             | 类型                      | 说明                           |
-| ---------------- | ------------------------- | ------------------------------ |
-| `tracks`         | `readonly AudioTrack[]`   | 播放列表与多格式 source 回退   |
-| `src`            | `AudioSourceInput`        | 单曲输入                       |
-| `nativeControls` | `boolean`                 | 强制浏览器原生控件             |
-| `repeatMode`     | `'off' \| 'one' \| 'all'` | 循环策略                       |
-| `playbackRate`   | `number`                  | 倍速，内核限制为 0.25–4        |
-| `mediaSession`   | `boolean`                 | 锁屏元数据与媒体按键，显式开启 |
-| `exclusive`      | `boolean`                 | 与同 `group` 实例互斥          |
-| `group`          | `string`                  | 实例协调分组                   |
+```ts
+import type {
+  AudioPlayerSize,
+  UseAudioPlayerOptions,
+  UseAudioPlayerResult,
+  VueAudioNativeProps,
+  AudioArtwork,
+  AudioBridgeEvent,
+  AudioControllerOptions,
+  AudioInput,
+  AudioPlayerBridge,
+  AudioPlayerError,
+  AudioPlayerErrorCode,
+  AudioPlayerHandle,
+  AudioRuntimeCapabilities,
+  AudioSnapshot,
+  AudioSource,
+  AudioSourceInput,
+  AudioTrack,
+  BufferedRange,
+  PlaybackState,
+  PreloadMode,
+  RepeatMode,
+} from 'vue-audio-native'
+```
 
-旧 `url`、`size`、`showCurrentTime`、`showControls`、`showVolume`、`showDownload`、
-`autoplay`、`waitBuffer`、`downloadName` 和 `hint` 继续受支持。
+`createAudioController()`、`normalizeInput()`、`normalizeSources()` 和
+`AudioControllerError` 只从 `@trsoliu/audio-core` 导出，Vue 包不会重新导出这些底层
+value：
 
-## 事件
+```ts
+import { createAudioController } from '@trsoliu/audio-core'
+import { VueAudioNative, useAudioPlayer } from 'vue-audio-native'
+```
 
-现代事件为 `ready`、`play`、`pause`、`ended`、`timeupdate`、`statechange`、
-`trackchange` 和 `error`。旧事件 `on-change`、`on-timeupdate`、`on-metadata`、
-`on-audioId` 保持兼容。
+## 输入模型
 
-## 命令句柄
+### `AudioSource` 与 `AudioSourceInput`
 
-组件通过 `defineExpose` 暴露 `AudioPlayerHandle`：播放、暂停、切换、停止、跳转、前后
-跳、选曲、上一首/下一首、音量、静音、倍速、循环模式和原生媒体元素访问。
+```ts
+interface AudioSource {
+  src: string
+  type?: string
+}
+
+type AudioSourceInput = string | AudioSource
+```
+
+`src` 可以接收一个 URL、一个带 MIME type 的 source，或它们的有序数组。空 URL 会被
+忽略，同一 URL 只保留第一次出现的位置。提供 `type` 时，内核优先选择
+`HTMLMediaElement.canPlayType()` 支持的 source；播放失败后会继续尝试后续 source。
+
+### `AudioTrack`
+
+| 字段           | 类型                                    | 必填 | 说明                                             |
+| -------------- | --------------------------------------- | ---- | ------------------------------------------------ |
+| `id`           | `string`                                | 是   | 调用方维护的稳定曲目标识                         |
+| `sources`      | `AudioSource \| readonly AudioSource[]` | 是   | 一个或多个有序回退源                             |
+| `title`        | `string`                                | 否   | 标题与 Media Session metadata                    |
+| `artist`       | `string`                                | 否   | 艺术家与 Media Session metadata                  |
+| `album`        | `string`                                | 否   | 专辑与 Media Session metadata                    |
+| `artwork`      | `MediaImage[]`                          | 否   | 默认封面与 Media Session artwork                 |
+| `downloadName` | `string`                                | 否   | 覆盖组件级下载文件名                             |
+| `peaks`        | `readonly number[]`                     | 否   | 调用方提供的波形峰值；播放器不会下载音频计算峰值 |
+
+非空 `tracks` 优先于 `src`，`src` 又优先于兼容 prop `url`。同时传入多个输入时，Vue
+组件会在开发环境给出警告。无可用 source 的 track 会被过滤；单独的 `src` 会被规范化
+为 `id: 'audio-source'` 的单曲播放列表。
+
+## `<VueAudioNative>` props
+
+### 输入与播放
+
+| prop           | 类型                                              | 默认值       | 行为                                                                            |
+| -------------- | ------------------------------------------------- | ------------ | ------------------------------------------------------------------------------- |
+| `tracks`       | `readonly AudioTrack[]`                           | —            | 播放列表；非空时覆盖 `src` 与 `url`                                             |
+| `src`          | `AudioSourceInput \| readonly AudioSourceInput[]` | —            | 单曲或多格式回退输入                                                            |
+| `url`          | `string`                                          | `''`         | 0.x 兼容输入，仅在 `tracks`、`src` 都不可用时生效                               |
+| `autoplay`     | `boolean`                                         | `false`      | 挂载或换源后尝试播放；浏览器阻止时发出可恢复的 `AUTOPLAY_BLOCKED`               |
+| `preload`      | `'none' \| 'metadata' \| 'auto'`                  | `'metadata'` | 写入原生 audio 的 preload 策略                                                  |
+| `volume`       | `number`                                          | `1`          | 有限值限制到 `0`–`1`；非有限初始值使用 `1`，后续非有限值忽略                    |
+| `muted`        | `boolean`                                         | `false`      | 静音状态                                                                        |
+| `playbackRate` | `number`                                          | `1`          | 有限值限制到 `0.25`–`4`；非有限初始值使用 `1`，后续非有限值忽略                 |
+| `repeatMode`   | `'off' \| 'one' \| 'all'`                         | `'off'`      | 不循环、单曲循环或列表循环                                                      |
+| `waitBuffer`   | `boolean`                                         | `true`       | `true` 允许跳到已知 duration 内任意位置；`false` 把 seek 限制到当前最大缓冲终点 |
+
+### 协作与浏览器集成
+
+| prop             | 类型      | 默认值      | 行为                                                             |
+| ---------------- | --------- | ----------- | ---------------------------------------------------------------- |
+| `exclusive`      | `boolean` | `false`     | 仅当两个实例都开启且 `group` 相同时，新播放实例才暂停另一个实例  |
+| `group`          | `string`  | `'default'` | 互斥分组；空白字符串按 `'default'` 处理                          |
+| `mediaSession`   | `boolean` | `false`     | 显式开启锁屏 metadata、播放状态与媒体按键处理                    |
+| `nativeControls` | `boolean` | 见说明      | 显式传入时决定是否强制原生 controls；未传时沿用旧 `showControls` |
+
+如果运行环境缺少自定义控件所需能力，即使 `nativeControls` 为 `false` 也会安全降级到
+原生 controls。组件本身不暴露 `bridge` prop；宿主 Bridge 请使用
+`useAudioPlayer({ bridge })`，或直接使用 core controller。
+
+### 展示与兼容 props
+
+| prop              | 类型                              | 默认值              | 行为                                                                  |
+| ----------------- | --------------------------------- | ------------------- | --------------------------------------------------------------------- |
+| `size`            | `'small' \| 'default' \| 'large'` | `'default'`         | 写入根节点 `data-size`，切换包内尺寸样式                              |
+| `showCurrentTime` | `boolean`                         | `true`              | 显示当前时间与 duration                                               |
+| `showVolume`      | `boolean`                         | `true`              | 显示静音按钮和音量滑杆                                                |
+| `showDownload`    | `boolean`                         | `true`              | 有 source 时显示下载链接；浏览器决定是否支持 `download` 和跨域下载    |
+| `downloadName`    | `string`                          | `''`                | 默认下载文件名；track 的同名字段优先                                  |
+| `hint`            | `string`                          | `'暂无有效音频...'` | 没有可播放 track 且未提供插槽时显示                                   |
+| `showControls`    | `boolean`                         | `false`             | 0.x 兼容项；仅在未显式传 `nativeControls` 时决定是否使用原生 controls |
+
+## 现代组件事件
+
+事件按 snapshot 变化发出，不等同于同名 DOM 事件。Vue 模板中建议使用 kebab-case
+监听名：
+
+| 事件          | payload                                           | 触发条件与注意事项                                                                                                                    |
+| ------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `statechange` | `(snapshot: AudioSnapshot)`                       | 每次 `PlaybackState` 真正变化时触发，包括 `loading`、`buffering` 和 `error`                                                           |
+| `ready`       | `(snapshot: AudioSnapshot)`                       | 状态进入 `ready` 时触发；通常来自暂停时的 `canplay`，加载阶段的 `play()` 被拒绝后也会进入这一可重试状态；不是 `loadedmetadata` 的别名 |
+| `play`        | `(snapshot: AudioSnapshot)`                       | 状态进入 `playing` 时触发；从 `buffering` 恢复也会再次触发                                                                            |
+| `pause`       | `(snapshot: AudioSnapshot)`                       | 状态进入 `paused` 时触发，包括命令暂停和同组互斥暂停                                                                                  |
+| `ended`       | `(snapshot: AudioSnapshot)`                       | 状态进入 `ended` 时触发；单曲循环、列表自动前进或列表循环时不会先发出终止事件                                                         |
+| `timeupdate`  | `(currentTime: number, snapshot: AudioSnapshot)`  | snapshot 的 `currentTime` 变化时触发；播放中也会由进度帧同步，频率可能高于原生 `timeupdate`                                           |
+| `trackchange` | `(track: AudioTrack \| null, trackIndex: number)` | 当前 track 的索引或对象发生变化时触发；初始选择请直接读取 snapshot，不要依赖一次“挂载事件”                                            |
+| `error`       | `(error: AudioPlayerError)`                       | 出现新的公开错误时触发；多 source 回退只在没有后续可尝试 source 后报告媒体错误                                                        |
+
+```vue
+<VueAudioNative
+  :tracks="tracks"
+  @statechange="onStateChange"
+  @timeupdate="(seconds, snapshot) => saveProgress(seconds, snapshot.track?.id)"
+  @trackchange="(track, index) => console.log(index, track?.id)"
+  @error="(error) => console.error(error.code, error.message)"
+/>
+```
+
+`AUTOPLAY_BLOCKED` 会触发 `error`，但 snapshot 通常保持 `ready` 或 `paused`，用户仍可通过
+手势再次调用 `play()`。因此不要把所有 `error` 都当作播放器永久不可用。
+
+## 0.x 兼容事件
+
+| 事件名          | Vue 监听写法     | payload                 | 与现代事件的关系                                                |
+| --------------- | ---------------- | ----------------------- | --------------------------------------------------------------- |
+| `on-change`     | `@on-change`     | `(playing: boolean)`    | 进入 `playing` 发 `true`；进入 `paused` 或 `ended` 发 `false`   |
+| `on-timeupdate` | `@on-timeupdate` | `(currentTime: number)` | 与现代 `timeupdate` 同时发出，但不包含 snapshot                 |
+| `on-metadata`   | `@on-metadata`   | `(event: Event)`        | 原生 `loadedmetadata` 或 `durationchange`；一次换源可能触发多次 |
+| `on-audioId`    | `@on-audio-id`   | `(id: string)`          | 组件挂载后发出一次，如 `vue-audio-native-1`                     |
+
+兼容事件只为迁移保留。新代码优先使用现代事件和 `AudioSnapshot`，尤其不要用
+`on-change` 推断 `loading`、`buffering` 或错误状态。
+
+## `AudioSnapshot`
+
+每次通知提供一个新的、顶层冻结的 snapshot：
+
+| 字段           | 类型                       | 说明                                           |
+| -------------- | -------------------------- | ---------------------------------------------- |
+| `state`        | `PlaybackState`            | 当前状态，见下表                               |
+| `track`        | `AudioTrack \| null`       | 当前规范化 track                               |
+| `trackIndex`   | `number`                   | 当前索引；没有 track 时为 `-1`                 |
+| `currentTime`  | `number`                   | 非负播放位置，单位秒                           |
+| `duration`     | `number \| null`           | 有效非负时长；未知、Infinity 或无效时为 `null` |
+| `buffered`     | `readonly BufferedRange[]` | `{ start, end }` 秒区间列表                    |
+| `volume`       | `number`                   | `0`–`1`                                        |
+| `muted`        | `boolean`                  | 是否静音                                       |
+| `playbackRate` | `number`                   | 当前倍速                                       |
+| `repeatMode`   | `RepeatMode`               | 当前循环模式                                   |
+| `error`        | `AudioPlayerError \| null` | 最近公开错误；成功播放或重新加载后清空         |
+
+| state       | 含义                                                                 |
+| ----------- | -------------------------------------------------------------------- |
+| `idle`      | 尚未附着媒体元素，或当前没有可用输入                                 |
+| `loading`   | 已选择 source，等待媒体就绪                                          |
+| `ready`     | 暂停且可重试；通常已收到 `canplay`，也可能刚从加载阶段的播放拒绝恢复 |
+| `playing`   | 正在播放                                                             |
+| `paused`    | 已暂停                                                               |
+| `buffering` | 播放期间收到 `waiting` 或 `stalled`                                  |
+| `ended`     | 播放列表到达终点且没有继续循环                                       |
+| `error`     | 所有可用 source 均失败，或发生其他致命媒体错误                       |
+
+## 结构化错误
+
+```ts
+interface AudioPlayerError {
+  code: AudioPlayerErrorCode
+  message: string
+  mediaErrorCode?: number
+  cause?: unknown
+}
+```
+
+| code                   | 常见来源                                              | 建议处理                                    |
+| ---------------------- | ----------------------------------------------------- | ------------------------------------------- |
+| `AUTOPLAY_BLOCKED`     | `play()` 被浏览器的用户手势策略拒绝                   | 显示播放按钮，让用户手势重试                |
+| `SOURCE_NOT_SUPPORTED` | 没有可用 source、原生错误码 4，或未附着媒体元素就播放 | 更换 source、检查 MIME/type，或先挂载 audio |
+| `MEDIA_ABORTED`        | 原生媒体错误码 1                                      | 允许重新加载或换源                          |
+| `NETWORK`              | 原生媒体错误码 2                                      | 提供重试并检查 URL/CORS/网络                |
+| `DECODE`               | 原生媒体错误码 3                                      | 换用兼容编码或后备 source                   |
+| `UNKNOWN`              | 其他 `play()` 或媒体失败                              | 记录 `cause`，向用户提供重试或后备路径      |
+
+## `AudioPlayerHandle`
+
+组件通过 `defineExpose` 暴露下列稳定句柄，composable 的 `controls` 使用同一接口：
+
+| 方法                    | 返回值                     | 语义                                                                            |
+| ----------------------- | -------------------------- | ------------------------------------------------------------------------------- |
+| `play()`                | `Promise<void>`            | 请求播放；失败时以结构化 `AudioControllerError` 拒绝                            |
+| `pause()`               | `void`                     | 暂停当前元素                                                                    |
+| `toggle()`              | `Promise<void>`            | 根据原生元素的 paused 状态播放或暂停                                            |
+| `stop()`                | `void`                     | 暂停并跳回 `0` 秒                                                               |
+| `seekTo(seconds)`       | `void`                     | 忽略非有限值，并把位置限制到合法时长；`waitBuffer=false` 时不能超过最大缓冲终点 |
+| `skipBy(seconds)`       | `void`                     | 从当前时间相对跳转                                                              |
+| `selectTrack(index)`    | `Promise<void>`            | 选择合法整数索引；越界时抛出 `RangeError`，原先在播或 autoplay 时继续播放       |
+| `previous()`            | `Promise<void>`            | 当前时间大于 3 秒时先回到本曲开头，否则切上一曲；`all` 可从首曲回绕             |
+| `next()`                | `Promise<void>`            | 切下一曲；`all` 可从末曲回绕，否则进入 `ended`                                  |
+| `setVolume(volume)`     | `void`                     | 把有限数值限制到 `0`–`1`；忽略 `NaN` 与无穷值                                   |
+| `setMuted(muted)`       | `void`                     | 更新静音状态                                                                    |
+| `setPlaybackRate(rate)` | `void`                     | 把有限数值限制到 `0.25`–`4`；忽略 `NaN` 与无穷值                                |
+| `setRepeatMode(mode)`   | `void`                     | 更新 `'off' \| 'one' \| 'all'`                                                  |
+| `getElement()`          | `HTMLAudioElement \| null` | 获取当前原生元素；SSR 或未挂载时为 `null`                                       |
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { VueAudioNative, type AudioPlayerHandle } from 'vue-audio-native'
+
+const player = ref<AudioPlayerHandle | null>(null)
+</script>
+
+<template>
+  <VueAudioNative ref="player" src="/episode.mp3" />
+  <button type="button" @click="void player?.play()">播放</button>
+</template>
+```
+
+## `useAudioPlayer()`
+
+```ts
+type UseAudioPlayerOptions = MaybeRefOrGetter<AudioControllerOptions>
+
+interface UseAudioPlayerResult {
+  audioRef: ShallowRef<HTMLAudioElement | null>
+  snapshot: ShallowRef<AudioSnapshot>
+  controls: AudioPlayerHandle
+}
+```
+
+在模板中使用 `ref="audioRef"`，不要写成普通 `src` 绑定：
+
+```vue
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useAudioPlayer } from 'vue-audio-native'
+
+const source = computed(() => '/episode.mp3')
+const { audioRef, controls, snapshot } = useAudioPlayer(() => ({
+  src: source.value,
+  bridge: null,
+  exclusive: true,
+  group: 'podcast',
+}))
+</script>
+
+<template>
+  <audio ref="audioRef" />
+  <button type="button" @click="void controls.toggle()">
+    {{ snapshot.state === 'playing' ? '暂停' : '播放' }}
+  </button>
+</template>
+```
+
+options 可以是普通对象、ref、computed 或 getter。composable 会响应输入和运行参数变化，
+并在当前 effect scope 销毁时取消订阅、解绑媒体元素和释放 controller。`bridge` 可以传对象
+或 `null`；移除旧 bridge 与换源同时发生时，旧宿主不会收到后续事件。
 
 ## 插槽
 
-保留 `slotTip`，并提供 `tip`、`artwork`、`before-controls`、`after-controls`。所有图标按钮
-均有可访问名称，键盘、Pointer 和触摸共用同一命令接口。
+| 插槽              | props                    | 渲染条件                               |
+| ----------------- | ------------------------ | -------------------------------------- |
+| `artwork`         | `{ track: AudioTrack }`  | 有当前 track 时；覆盖默认首张 artwork  |
+| `before-controls` | `{ controls, snapshot }` | 使用自定义 controls 且有 track 时      |
+| `after-controls`  | `{ controls, snapshot }` | 使用自定义 controls 且有 track 时      |
+| `tip`             | 无                       | 没有可播放 track 时，优先于 `slotTip`  |
+| `slotTip`         | 无                       | 0.x 兼容 fallback；未提供 `tip` 时使用 |
 
-具体签名以 npm 包生成的 `.d.ts` 为准；发布门禁通过 Are The Types Wrong 和
-`publint` 验证 ESM、CJS 与类型解析。
+## 直接使用 `@trsoliu/audio-core`
+
+```ts
+import { createAudioController } from '@trsoliu/audio-core'
+
+const controller = createAudioController({ src: '/episode.mp3' })
+const unsubscribe = controller.subscribe((snapshot) => {
+  console.log(snapshot.state, snapshot.currentTime)
+})
+
+controller.attach(document.querySelector('audio'))
+```
+
+`subscribe()` 不会立即回放当前值；需要初始值时先调用 `getSnapshot()`。listener 会在任何
+snapshot 发布时收到完整值，不只是在 state 改变时收到。底层 `AudioController` 还提供：
+
+| 方法                        | 说明                                                            |
+| --------------------------- | --------------------------------------------------------------- |
+| `attach(element \| null)`   | 绑定、换绑或解绑真实 `HTMLAudioElement`                         |
+| `destroy()`                 | 移除监听器、进度帧、互斥注册和 Media Session 所有权；可重复调用 |
+| `getSnapshot()`             | 同步读取当前不可变 snapshot                                     |
+| `setInput({ src, tracks })` | 替换输入并把选择重置到首个有效 track                            |
+| `subscribe(listener)`       | 订阅 snapshot，返回幂等取消函数                                 |
+| `updateOptions(partial)`    | 合并运行选项；`bridge: null` 明确解绑宿主                       |
+
+### Bridge Events
+
+Bridge 是协议无关的单向出口：
+
+```ts
+type AudioBridgeEvent =
+  | { type: 'statechange'; snapshot: AudioSnapshot }
+  | {
+      type: 'trackchange'
+      snapshot: AudioSnapshot
+      track: AudioTrack | null
+      trackIndex: number
+    }
+  | { type: 'error'; snapshot: AudioSnapshot; error: AudioPlayerError }
+```
+
+- `statechange` 只在 `snapshot.state` 改变时发送。
+- `trackchange` 在当前 track/index 改变时发送；附着已有选中 track 的 controller 时也会
+  向当前 bridge 发送一次。
+- `error` 只在出现新的公开错误对象时发送。
+- `bridge.emit()` 抛出的宿主异常会被隔离，不会中断播放。
+
+Bridge 不规定 WKWebView、Android `JavascriptInterface` 或 ArkWeb 的消息格式；宿主负责
+序列化、鉴权和生命周期管理。
+
+## Core 工具函数
+
+| API                                 | 行为                                                                                                 |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `detectAudioCapabilities(element?)` | 返回 custom controls、download、Media Session、原生 HLS、Pointer 和 touch 能力；SSR 时全部为 `false` |
+| `formatMediaTime(seconds)`          | 无效、负数或未知值返回 `--:--`，否则返回补零时间                                                     |
+| `normalizeSources(input)`           | trim、过滤空 URL、按 URL 去重并保留顺序                                                              |
+| `normalizeInput(input)`             | 规范化 playlist；非空 tracks 优先，单 src 生成合成 track                                             |
+| `AudioControllerError`              | 带 `code`、可选 `mediaErrorCode` 和 `cause` 的公开 Error 类                                          |
+
+具体声明仍以已发布包的 `.d.ts` 为最终机器契约；发布门禁会验证 ESM、CJS、类型解析、
+SSR 导入和 npm tarball 内容。

--- a/docs/guide/getting-started.mdx
+++ b/docs/guide/getting-started.mdx
@@ -69,7 +69,7 @@ const { audioRef, controls, snapshot } = useAudioPlayer({
 </script>
 
 <template>
-  <audio :ref="audioRef" />
+  <audio ref="audioRef" />
   <button type="button" @click="controls.toggle()">
     {{ snapshot.state === 'playing' ? 'Pause' : 'Play' }}
   </button>

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -23,11 +23,11 @@ Vue Audio Native 1.0 不只是一个播放器组件。它把浏览器媒体状�
 
 ## 快速索引
 
-| 目标                             | 文档                                        |
-| -------------------------------- | ------------------------------------------- |
-| 安装并播放第一段音频             | [安装与快速开始](./guide/getting-started/)  |
-| 从 0.x 或 Vue 2 迁移             | [Vue 1.0 迁移指南](./migration-v1/)         |
-| 查找 props、事件、插槽和句柄     | [公共 API](./api/)                          |
-| 理解 core、Vue、Demo 与 fixtures | [Monorepo 项目地图](./project-map/)         |
-| 处理浏览器/WebView 差异          | [浏览器与 WebView](./wiki/browser-webview/) |
-| 准备 beta 或稳定发布             | [发布知识库](./wiki/release/)               |
+| 目标                                             | 文档                                        |
+| ------------------------------------------------ | ------------------------------------------- |
+| 安装并播放第一段音频                             | [安装与快速开始](./guide/getting-started/)  |
+| 从 0.x 或 Vue 2 迁移                             | [Vue 1.0 迁移指南](./migration-v1/)         |
+| 查找 props、事件 payload、状态、错误、插槽和句柄 | [公共 API](./api/)                          |
+| 理解 core、Vue、Demo 与 fixtures                 | [Monorepo 项目地图](./project-map/)         |
+| 处理浏览器/WebView 差异                          | [浏览器与 WebView](./wiki/browser-webview/) |
+| 准备 beta 或稳定发布                             | [发布知识库](./wiki/release/)               |

--- a/packages/audio-core/README.md
+++ b/packages/audio-core/README.md
@@ -1,27 +1,134 @@
 # @trsoliu/audio-core
 
-Typed, framework-independent control for the browser `HTMLAudioElement`. The package creates no
-DOM or media elements during import, so it is safe to import from SSR code.
+Typed, framework-independent control for the browser `HTMLAudioElement`. It provides the shared
+playback contract used by `vue-audio-native` and `react-audio-native`: event-driven snapshots,
+playlists, ordered source fallback, structured errors, repeat modes, Media Session, exclusive
+groups, and a protocol-neutral WebView Bridge.
+
+The package creates no DOM or media objects during import, so it is safe to import from SSR code.
+
+## Install
+
+```bash
+pnpm add @trsoliu/audio-core@next
+```
+
+The 1.0 line is currently a prerelease. Use the `next` tag while validating it.
+
+## Exports
+
+Runtime values:
+
+- `createAudioController()`
+- `detectAudioCapabilities()`
+- `formatMediaTime()`
+- `normalizeInput()` and `normalizeSources()`
+- `AudioControllerError`
+
+Type-only exports:
+
+```ts
+import type {
+  AudioController,
+  AudioControllerOptions,
+  AudioBridgeEvent,
+  AudioArtwork,
+  AudioInput,
+  AudioPlayerBridge,
+  AudioPlayerError,
+  AudioPlayerErrorCode,
+  AudioPlayerHandle,
+  AudioRuntimeCapabilities,
+  AudioSnapshot,
+  AudioSnapshotListener,
+  AudioSource,
+  AudioSourceInput,
+  AudioTrack,
+  BufferedRange,
+  PlaybackState,
+  PreloadMode,
+  RepeatMode,
+} from '@trsoliu/audio-core'
+```
+
+## Quick start
 
 ```ts
 import { createAudioController } from '@trsoliu/audio-core'
 
-const controller = createAudioController({ src: '/audio/example.mp3' })
-controller.attach(document.querySelector('audio'))
-await controller.play()
+const audio = document.querySelector<HTMLAudioElement>('#player')
+const controller = createAudioController({
+  src: '/audio/example.mp3',
+  preload: 'metadata',
+})
+
+const unsubscribe = controller.subscribe((snapshot) => {
+  console.log(snapshot.state, snapshot.currentTime)
+})
+
+controller.attach(audio)
+
+document.querySelector('#play')?.addEventListener('click', () => {
+  void controller.play().catch((error) => {
+    console.error(error.code, error.message)
+  })
+})
+
+// On teardown:
+unsubscribe()
+controller.destroy()
 ```
 
-The controller is event-driven, SSR-safe, and includes playlists, repeat modes,
-source fallback, buffered seeking, Media Session integration, and optional
-cross-instance playback coordination.
+`subscribe()` reports published snapshot changes but does not immediately replay the current
+value. Call `controller.getSnapshot()` when you also need the initial state.
 
-## Playlist and source fallback
+## Inputs
+
+### Sources
+
+```ts
+interface AudioSource {
+  src: string
+  type?: string
+}
+
+type AudioSourceInput = string | AudioSource
+```
+
+`src` accepts one URL, one typed source, or an ordered array of either form. Empty URLs are ignored
+and duplicate URLs keep their first position. A MIME `type` lets the controller prefer a source
+supported by `HTMLMediaElement.canPlayType()`.
+
+### Tracks
+
+```ts
+interface AudioTrack {
+  id: string
+  title?: string
+  artist?: string
+  album?: string
+  artwork?: MediaImage[]
+  sources: AudioSource | readonly AudioSource[]
+  downloadName?: string
+  peaks?: readonly number[]
+}
+```
+
+Non-empty `tracks` take precedence over `src`. Tracks with no usable source are removed. A lone
+`src` becomes a synthetic track with `id: 'audio-source'`.
+
+Sources are attempted in order. A media failure advances to the next source without publishing a
+fatal error; `error` is reported after the final source fails. Native HLS URLs may be passed
+through, but the package does not bundle `hls.js`, fetch or decode audio, use Web Audio, or derive
+waveform peaks.
 
 ```ts
 const controller = createAudioController({
   tracks: [
     {
       id: 'episode-1',
+      title: 'Episode 1',
+      artist: 'Audio Native',
       sources: [
         { src: '/episode-1.ogg', type: 'audio/ogg' },
         { src: '/episode-1.mp3', type: 'audio/mpeg' },
@@ -32,28 +139,221 @@ const controller = createAudioController({
 })
 ```
 
-Sources are selected with `HTMLMediaElement.canPlayType()` and retried on media failure. Native HLS
-URLs may be passed through; the package does not bundle `hls.js`, decode media or use Web Audio.
+## Controller options
 
-## WebView host adapter
+| Option         | Type                                              | Default      | Behavior                                                          |
+| -------------- | ------------------------------------------------- | ------------ | ----------------------------------------------------------------- |
+| `src`          | `AudioSourceInput \| readonly AudioSourceInput[]` | —            | Single-track input and ordered format fallback                    |
+| `tracks`       | `readonly AudioTrack[]`                           | —            | Playlist; non-empty values override `src`                         |
+| `autoplay`     | `boolean`                                         | `false`      | Attempts playback after attach or an input change                 |
+| `preload`      | `'none' \| 'metadata' \| 'auto'`                  | `'metadata'` | Native audio preload value                                        |
+| `volume`       | `number`                                          | `1`          | Finite values clamp to `0`–`1`; non-finite input uses `1`         |
+| `muted`        | `boolean`                                         | `false`      | Native muted state                                                |
+| `playbackRate` | `number`                                          | `1`          | Finite values clamp to `0.25`–`4`; non-finite input uses `1`      |
+| `repeatMode`   | `'off' \| 'one' \| 'all'`                         | `'off'`      | End-of-track behavior                                             |
+| `waitBuffer`   | `boolean`                                         | `true`       | When `false`, seeking is capped at the greatest buffered end time |
+| `exclusive`    | `boolean`                                         | `false`      | Enables cross-instance pause coordination                         |
+| `group`        | `string`                                          | `'default'`  | Coordination group; blank values resolve to `default`             |
+| `mediaSession` | `boolean`                                         | `false`      | Opts into Media Session metadata, actions, and playback state     |
+| `bridge`       | `AudioPlayerBridge \| null`                       | `null`       | Optional protocol-neutral host event sink                         |
 
-The optional bridge is a protocol-neutral callback. It does not assume Android JavascriptInterface,
-WKWebView message handlers or an ArkWeb protocol.
+Autoplay rejection is published as the recoverable `AUTOPLAY_BLOCKED` error. It leaves the
+controller usable, so a later user gesture can call `play()` again.
+
+## `AudioController`
+
+`createAudioController(options?)` returns an `AudioController` with these methods:
+
+| Method                   | Return                     | Behavior                                                                                                                  |
+| ------------------------ | -------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `attach(element)`        | `void`                     | Attaches, replaces, or detaches (`null`) a real `HTMLAudioElement`                                                        |
+| `destroy()`              | `void`                     | Removes media listeners, animation frames, coordinator registration, Media Session ownership, and subscribers; idempotent |
+| `getSnapshot()`          | `AudioSnapshot`            | Reads the current immutable snapshot synchronously                                                                        |
+| `subscribe(listener)`    | `() => void`               | Subscribes to future snapshot publications and returns an unsubscribe function                                            |
+| `setInput(input)`        | `void`                     | Replaces the input and resets selection to the first valid track                                                          |
+| `updateOptions(partial)` | `void`                     | Merges runtime options; pass `bridge: null` to detach a host                                                              |
+| `play()`                 | `Promise<void>`            | Requests playback and rejects with `AudioControllerError` on failure                                                      |
+| `pause()`                | `void`                     | Pauses the attached element                                                                                               |
+| `toggle()`               | `Promise<void>`            | Plays or pauses according to the element's native `paused` state                                                          |
+| `stop()`                 | `void`                     | Pauses and seeks to `0`                                                                                                   |
+| `seekTo(seconds)`        | `void`                     | Ignores non-finite values and clamps to duration/buffer policy                                                            |
+| `skipBy(seconds)`        | `void`                     | Seeks relative to the current time                                                                                        |
+| `selectTrack(index)`     | `Promise<void>`            | Selects an integer playlist index; rejects with `RangeError` when out of range                                            |
+| `previous()`             | `Promise<void>`            | Restarts the current track after 3 seconds; otherwise selects the previous track or wraps in `all` mode                   |
+| `next()`                 | `Promise<void>`            | Selects the next track, wraps in `all` mode, or enters `ended` at the boundary                                            |
+| `setVolume(value)`       | `void`                     | Clamps finite values to `0`–`1` and ignores non-finite values                                                             |
+| `setMuted(value)`        | `void`                     | Updates muted state                                                                                                       |
+| `setPlaybackRate(value)` | `void`                     | Clamps finite values to `0.25`–`4` and ignores non-finite values                                                          |
+| `setRepeatMode(mode)`    | `void`                     | Sets `off`, `one`, or `all`                                                                                               |
+| `getElement()`           | `HTMLAudioElement \| null` | Returns the current native element                                                                                        |
+
+Calling `play()` without both an attached element and a valid track rejects with
+`SOURCE_NOT_SUPPORTED`. `selectTrack()` preserves playback when the player was already playing or
+when `autoplay` is enabled.
+
+## Snapshots and playback events
+
+Media state is driven by standard media events. While playback is active, requestAnimationFrame is
+used only to keep time and buffered data smooth; there is no ready-state polling or persistent
+background timer.
 
 ```ts
-const controller = createAudioController({
-  bridge: {
-    emit(event) {
-      hostTransport.send(JSON.stringify(event))
-    },
+interface AudioSnapshot {
+  state: PlaybackState
+  track: AudioTrack | null
+  trackIndex: number
+  currentTime: number
+  duration: number | null
+  buffered: readonly { start: number; end: number }[]
+  volume: number
+  muted: boolean
+  playbackRate: number
+  repeatMode: RepeatMode
+  error: AudioPlayerError | null
+}
+```
+
+Each publication is a new, top-level frozen object. A listener can receive updates without a state
+transition—for example, time, duration, buffering, volume, or rate changes.
+
+| State       | Meaning                                                                                            |
+| ----------- | -------------------------------------------------------------------------------------------------- |
+| `idle`      | No attached media element yet, or no valid input                                                   |
+| `loading`   | A source has been selected and loading has started                                                 |
+| `ready`     | Paused/retryable; normally entered by `canplay`, or after a play request is rejected while loading |
+| `playing`   | Playback is active                                                                                 |
+| `paused`    | Playback is paused                                                                                 |
+| `buffering` | `waiting` or `stalled` occurred during active playback                                             |
+| `ended`     | The playlist reached its boundary without another repeat/track transition                          |
+| `error`     | All usable sources failed or another fatal media error occurred                                    |
+
+`ready` is not an alias for `loadedmetadata`. A transition from `buffering` back to `playing` is a
+new state transition even though the user did not issue another play command.
+
+### Native media event mapping
+
+| Native event                       | Published behavior                                                                                                            |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `loadstart`                        | Clears the previous error and enters `loading`                                                                                |
+| `loadedmetadata`, `durationchange` | Synchronizes time, duration, buffered ranges, volume, mute, and rate without treating metadata as `ready`                     |
+| `canplay`                          | Enters `ready`/`playing` from `loading`, or returns active `buffering` to `playing`; a late event does not overwrite `paused` |
+| `play`                             | Clears the error, enters `playing`, coordinates exclusive peers, and activates Media Session                                  |
+| `playing`                          | Confirms `playing`, updates Media Session, and starts smooth progress synchronization                                         |
+| `pause`                            | Enters `paused` unless the snapshot is already terminal `ended`/`error`                                                       |
+| `waiting`, `stalled`               | Enters `buffering` only while the element is actively playing                                                                 |
+| `timeupdate`, `progress`           | Synchronizes time, duration, and buffered ranges                                                                              |
+| `volumechange`                     | Synchronizes `volume` and `muted`                                                                                             |
+| `ratechange`                       | Synchronizes `playbackRate`                                                                                                   |
+| `ended`                            | Repeats, advances the playlist, wraps, or enters terminal `ended` according to the current mode                               |
+| `error`                            | Loads the next ordered source, or publishes a structured fatal error when no fallback remains                                 |
+
+## Structured errors
+
+```ts
+interface AudioPlayerError {
+  code:
+    | 'AUTOPLAY_BLOCKED'
+    | 'SOURCE_NOT_SUPPORTED'
+    | 'MEDIA_ABORTED'
+    | 'NETWORK'
+    | 'DECODE'
+    | 'UNKNOWN'
+  message: string
+  mediaErrorCode?: number
+  cause?: unknown
+}
+```
+
+| Code                   | Typical source                                                                | Recovery                                              |
+| ---------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------- |
+| `AUTOPLAY_BLOCKED`     | `NotAllowedError` from browser gesture policy                                 | Let the user call `play()` from a gesture             |
+| `SOURCE_NOT_SUPPORTED` | Missing input/element, native media error 4, or exhausted unsupported sources | Attach an element or provide another format           |
+| `MEDIA_ABORTED`        | Native media error 1                                                          | Reload or replace the source                          |
+| `NETWORK`              | Native media error 2                                                          | Retry and inspect URL, CORS, and connectivity         |
+| `DECODE`               | Native media error 3                                                          | Use a compatible encoding or fallback source          |
+| `UNKNOWN`              | Other play/media failures                                                     | Inspect `cause`, log safely, and offer retry/fallback |
+
+`AudioControllerError` extends `Error` and implements this public shape. A recoverable play error
+can coexist with `state: 'ready'` or `state: 'paused'`; do not treat every error as fatal.
+
+## WebView Bridge events
+
+The optional bridge receives state, track, and error transitions without assuming a host protocol:
+
+```ts
+import type { AudioPlayerBridge } from '@trsoliu/audio-core'
+
+const bridge: AudioPlayerBridge = {
+  emit(event) {
+    hostTransport.send(JSON.stringify(event))
   },
-  src: '/audio/example.mp3',
+}
+
+const controller = createAudioController({ bridge, src: '/episode.mp3' })
+```
+
+```ts
+type AudioBridgeEvent =
+  | { type: 'statechange'; snapshot: AudioSnapshot }
+  | {
+      type: 'trackchange'
+      snapshot: AudioSnapshot
+      track: AudioTrack | null
+      trackIndex: number
+    }
+  | { type: 'error'; snapshot: AudioSnapshot; error: AudioPlayerError }
+```
+
+- `statechange` is emitted only when `snapshot.state` changes.
+- `trackchange` is emitted when the track/index changes and once on attach when a track is already
+  selected.
+- `error` is emitted when a new public error object appears.
+- Exceptions thrown by `bridge.emit()` are isolated from playback.
+- `controller.updateOptions({ bridge: null })` detaches the old host before any simultaneous input
+  update is delivered.
+
+Map these events to `WKScriptMessageHandler`, Android `JavascriptInterface`, ArkWeb, or another
+transport in host code. The package intentionally defines no message channel, authentication, or
+serialization protocol.
+
+## Exclusive groups
+
+Instances remain independent by default. A player pauses a peer only when both have
+`exclusive: true` and their trimmed `group` values match:
+
+```ts
+const narration = createAudioController({
+  src: '/narration.mp3',
+  exclusive: true,
+  group: 'content',
 })
 ```
 
-Call `controller.updateOptions({ bridge: null })` to detach the host before a WebView is recycled or
-its transport is replaced. No later track, state or error event is delivered to the old bridge.
+## Media Session
 
-Host exceptions are isolated from playback. `detectAudioCapabilities()` reports custom-control,
-download, Media Session, native HLS, Pointer Events and touch capabilities without parsing the user
-agent.
+Media Session is opt-in with `mediaSession: true`. When supported, the active owner publishes track
+metadata and handles play, pause, stop, previous/next, seek backward/forward, and seek-to actions.
+Unsupported actions are ignored. Disabling the option or destroying the owner clears handlers,
+metadata, and playback state.
+
+## Capability and normalization helpers
+
+| Export                              | Behavior                                                                                                                                           |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `detectAudioCapabilities(element?)` | Reports custom controls, download, Media Session, native HLS, Pointer Events, and touch without user-agent parsing; returns all `false` during SSR |
+| `formatMediaTime(seconds)`          | Returns `mm:ss`/`hh:mm:ss`; invalid, negative, infinite, or unknown values become `--:--`                                                          |
+| `normalizeSources(input)`           | Trims URLs, removes empties and duplicate URLs, preserves order                                                                                    |
+| `normalizeInput(input)`             | Normalizes tracks or creates the synthetic single-source track                                                                                     |
+| `AudioControllerError`              | Public structured `Error` class                                                                                                                    |
+
+## Runtime boundaries
+
+- Browser-first and SSR-import safe; Node.js 18+ is required for the package toolchain/runtime
+  distribution.
+- Capability detection replaces user-agent branching.
+- Native HLS is passed through when supported; no streaming engine is bundled.
+- React Native native SDKs, recording, DRM, transcoding, audio analysis, and automatic waveform
+  generation are outside scope.
+
+The package publishes ESM, CommonJS, and declarations. The generated `.d.ts` files are the final
+machine-readable API contract.

--- a/packages/audio-core/src/controller.ts
+++ b/packages/audio-core/src/controller.ts
@@ -31,6 +31,13 @@ let activeMediaSessionOwner: string | null = null
 const clamp = (value: number, minimum: number, maximum: number): number =>
   Math.min(maximum, Math.max(minimum, value))
 
+const clampFinite = (
+  value: number,
+  fallback: number,
+  minimum: number,
+  maximum: number,
+): number => (Number.isFinite(value) ? clamp(value, minimum, maximum) : fallback)
+
 const finiteOrNull = (value: number): number | null =>
   Number.isFinite(value) && value >= 0 ? value : null
 
@@ -68,12 +75,12 @@ export function createAudioController(
     duration: null,
     error: null,
     muted: options.muted ?? false,
-    playbackRate: clamp(options.playbackRate ?? 1, 0.25, 4),
+    playbackRate: clampFinite(options.playbackRate ?? 1, 1, 0.25, 4),
     repeatMode: options.repeatMode ?? 'off',
     state: 'idle',
     track: tracks[trackIndex] ?? null,
     trackIndex,
-    volume: clamp(options.volume ?? 1, 0, 1),
+    volume: clampFinite(options.volume ?? 1, 1, 0, 1),
   })
 
   function emitBridge(event: AudioBridgeEvent): void {
@@ -120,8 +127,13 @@ export function createAudioController(
         : 0,
       duration: finiteOrNull(element.duration),
       muted: element.muted,
-      playbackRate: element.playbackRate,
-      volume: element.volume,
+      playbackRate: clampFinite(
+        element.playbackRate,
+        snapshot.playbackRate,
+        0.25,
+        4,
+      ),
+      volume: clampFinite(element.volume, snapshot.volume, 0, 1),
     })
   }
 
@@ -285,11 +297,23 @@ export function createAudioController(
 
   function onVolumeChange(): void {
     if (!element) return
-    patch({ muted: element.muted, volume: element.volume })
+    patch({
+      muted: element.muted,
+      volume: clampFinite(element.volume, snapshot.volume, 0, 1),
+    })
   }
 
   function onRateChange(): void {
-    if (element) patch({ playbackRate: element.playbackRate })
+    if (element) {
+      patch({
+        playbackRate: clampFinite(
+          element.playbackRate,
+          snapshot.playbackRate,
+          0.25,
+          4,
+        ),
+      })
+    }
   }
 
   function onError(): void {
@@ -456,6 +480,7 @@ export function createAudioController(
   }
 
   function setVolume(volume: number): void {
+    if (!Number.isFinite(volume)) return
     const next = clamp(volume, 0, 1)
     if (element) element.volume = next
     patch({ volume: next })
@@ -467,6 +492,7 @@ export function createAudioController(
   }
 
   function setPlaybackRate(playbackRate: number): void {
+    if (!Number.isFinite(playbackRate)) return
     const next = clamp(playbackRate, 0.25, 4)
     if (element) element.playbackRate = next
     patch({ playbackRate: next })

--- a/packages/audio-core/tests/controller.test.ts
+++ b/packages/audio-core/tests/controller.test.ts
@@ -259,6 +259,41 @@ describe('createAudioController', () => {
     })
   })
 
+  it('keeps volume and playback rate finite when inputs are non-finite', () => {
+    const audio = new FakeAudioElement()
+    const controller = createAudioController({
+      playbackRate: Number.POSITIVE_INFINITY,
+      src: 'one.mp3',
+      volume: Number.NaN,
+    })
+
+    expect(controller.getSnapshot()).toMatchObject({
+      playbackRate: 1,
+      volume: 1,
+    })
+
+    controller.attach(audio.asAudioElement())
+    controller.setVolume(Number.NaN)
+    controller.setPlaybackRate(Number.NEGATIVE_INFINITY)
+
+    expect(controller.getSnapshot()).toMatchObject({
+      playbackRate: 1,
+      volume: 1,
+    })
+    expect(audio.playbackRate).toBe(1)
+    expect(audio.volume).toBe(1)
+
+    audio.volume = Number.NaN
+    audio.playbackRate = Number.POSITIVE_INFINITY
+    audio.emit('volumechange')
+    audio.emit('ratechange')
+
+    expect(controller.getSnapshot()).toMatchObject({
+      playbackRate: 1,
+      volume: 1,
+    })
+  })
+
   it('supports skip, previous, next, and validated track selection', async () => {
     const audio = new FakeAudioElement()
     audio.duration = 100

--- a/packages/vue-audio-native/README.md
+++ b/packages/vue-audio-native/README.md
@@ -1,44 +1,360 @@
 # vue-audio-native
 
-Typed Vue 3 audio player for browsers and embedded WebViews, with modern and legacy-compatible APIs.
-Vue `>=3.3 <4` is a peer dependency.
+An accessible, typed Vue 3 audio player for desktop/mobile browsers and embedded WebViews. It uses
+the event-driven `@trsoliu/audio-core` contract for playlists, ordered source fallback, repeat
+modes, buffered seeking, structured errors, Media Session, optional exclusive groups, and a
+protocol-neutral host Bridge.
+
+Version 1.x targets Vue `>=3.3 <4`. Vue 2 applications must stay on the legacy line.
+
+## Install
+
+```bash
+# Vue 3 prerelease
+pnpm add vue-audio-native@next
+
+# Vue 2 compatibility line
+pnpm add vue-audio-native@legacy
+```
+
+Import the standalone package CSS; consumers do not need Tailwind:
 
 ```ts
 import { createApp } from 'vue'
-import VueAudioNative from 'vue-audio-native'
+import VueAudioNativePlugin from 'vue-audio-native'
 import 'vue-audio-native/style.css'
 
-createApp(App).use(VueAudioNative).mount('#app')
+createApp(App).use(VueAudioNativePlugin).mount('#app')
 ```
+
+The plugin registers both `<VueAudioNative>` and `<AudioPlayer>`. Named component imports are also
+supported.
+
+## Quick start
 
 ```vue
-<VueAudioNative
-  :tracks="tracks"
-  repeat-mode="all"
-  :media-session="true"
-  @statechange="snapshot => console.log(snapshot.state)"
-/>
+<script setup lang="ts">
+import { VueAudioNative, type AudioTrack } from 'vue-audio-native'
+import 'vue-audio-native/style.css'
+
+const tracks: readonly AudioTrack[] = [
+  {
+    id: 'episode-1',
+    title: 'Episode 1',
+    artist: 'Audio Native',
+    artwork: [{ src: '/cover.webp', sizes: '512x512', type: 'image/webp' }],
+    sources: [
+      { src: '/episode-1.ogg', type: 'audio/ogg' },
+      { src: '/episode-1.mp3', type: 'audio/mpeg' },
+    ],
+  },
+]
+
+function onError(error: { code: string; message: string }) {
+  console.error(error.code, error.message)
+}
+</script>
+
+<template>
+  <VueAudioNative
+    :tracks="tracks"
+    repeat-mode="all"
+    media-session
+    @statechange="(snapshot) => console.log(snapshot.state)"
+    @error="onError"
+  />
+</template>
 ```
 
-The legacy `url`, display props, `on-*` events, `slotTip`, component name, and
-`app.use()` registration remain available in version 1.x. Vue 2 projects should
-install `vue-audio-native@legacy`.
+Input priority is fixed: non-empty `tracks`, then `src`, then legacy `url`. The component warns in
+development when more than one input is provided.
 
 ## Exports
 
-- `VueAudioNative` and alias `AudioPlayer`
-- default Vue plugin for `app.use()`
-- `useAudioPlayer()` headless composable
-- `detectAudioCapabilities()`
-- all controller, track, snapshot, bridge and error types from `@trsoliu/audio-core`
+Runtime exports from `vue-audio-native`:
 
-The component exposes `AudioPlayerHandle` through template refs. Inputs resolve in this order:
-non-empty `tracks`, then `src`, then legacy `url`.
+- `VueAudioNative` and its `AudioPlayer` alias
+- the default Vue plugin for `app.use()`
+- `useAudioPlayer()`
+- `detectAudioCapabilities()` and `formatMediaTime()`
+
+Complete type-only exports:
+
+```ts
+import type {
+  AudioPlayerSize,
+  UseAudioPlayerOptions,
+  UseAudioPlayerResult,
+  VueAudioNativeProps,
+  AudioArtwork,
+  AudioBridgeEvent,
+  AudioControllerOptions,
+  AudioInput,
+  AudioPlayerBridge,
+  AudioPlayerError,
+  AudioPlayerErrorCode,
+  AudioPlayerHandle,
+  AudioRuntimeCapabilities,
+  AudioSnapshot,
+  AudioSource,
+  AudioSourceInput,
+  AudioTrack,
+  BufferedRange,
+  PlaybackState,
+  PreloadMode,
+  RepeatMode,
+} from 'vue-audio-native'
+```
+
+For the low-level controller, import directly from `@trsoliu/audio-core`. The Vue package does not
+re-export the `createAudioController`, normalization helpers, or `AudioControllerError` runtime
+values.
+
+## Inputs
+
+```ts
+interface AudioSource {
+  src: string
+  type?: string
+}
+
+interface AudioTrack {
+  id: string
+  title?: string
+  artist?: string
+  album?: string
+  artwork?: MediaImage[]
+  sources: AudioSource | readonly AudioSource[]
+  downloadName?: string
+  peaks?: readonly number[]
+}
+```
+
+`src` accepts a URL, one typed source, or an ordered array of either. Empty URLs are removed and
+duplicate URLs keep their first position. The core uses `canPlayType()` to prefer supported MIME
+types, then tries later sources after media failure. A fatal error is reported only after the final
+source fails.
+
+Waveforms render only caller-provided `peaks`; the package never fetches or decodes audio to derive
+them.
+
+## Component props
+
+### Input and playback
+
+| Prop           | Type                                              | Default      | Behavior                                                                    |
+| -------------- | ------------------------------------------------- | ------------ | --------------------------------------------------------------------------- |
+| `tracks`       | `readonly AudioTrack[]`                           | —            | Playlist; non-empty values override `src` and `url`                         |
+| `src`          | `AudioSourceInput \| readonly AudioSourceInput[]` | —            | Single item with ordered source fallback                                    |
+| `url`          | `string`                                          | `''`         | Legacy single URL; used only when modern inputs are empty                   |
+| `autoplay`     | `boolean`                                         | `false`      | Attempts playback after mount/input change; policy rejection is recoverable |
+| `preload`      | `'none' \| 'metadata' \| 'auto'`                  | `'metadata'` | Native `<audio>` preload mode                                               |
+| `volume`       | `number`                                          | `1`          | Finite values clamp to `0`–`1`; non-finite values are ignored               |
+| `muted`        | `boolean`                                         | `false`      | Native muted state                                                          |
+| `playbackRate` | `number`                                          | `1`          | Finite values clamp to `0.25`–`4`; non-finite values are ignored            |
+| `repeatMode`   | `'off' \| 'one' \| 'all'`                         | `'off'`      | End-of-track behavior                                                       |
+| `waitBuffer`   | `boolean`                                         | `true`       | When `false`, seeking cannot move beyond the greatest buffered end time     |
+
+### Integration and presentation
+
+| Prop              | Type                              | Default             | Behavior                                                                                  |
+| ----------------- | --------------------------------- | ------------------- | ----------------------------------------------------------------------------------------- |
+| `exclusive`       | `boolean`                         | `false`             | Pauses peers only when both players are exclusive and share a group                       |
+| `group`           | `string`                          | `'default'`         | Exclusive coordination group; blank values become `default`                               |
+| `mediaSession`    | `boolean`                         | `false`             | Opts into lock-screen metadata, playback state, and media actions                         |
+| `nativeControls`  | `boolean`                         | see note            | Explicitly forces/hides native controls; when omitted, legacy `showControls` is used      |
+| `showControls`    | `boolean`                         | `false`             | Legacy native-controls option, used only when `nativeControls` is not explicitly supplied |
+| `showCurrentTime` | `boolean`                         | `true`              | Shows current time and duration in custom controls                                        |
+| `showVolume`      | `boolean`                         | `true`              | Shows mute and volume controls                                                            |
+| `showDownload`    | `boolean`                         | `true`              | Shows a link when a source exists; the browser decides `download`/cross-origin support    |
+| `downloadName`    | `string`                          | `''`                | Fallback filename; `track.downloadName` wins                                              |
+| `size`            | `'small' \| 'default' \| 'large'` | `'default'`         | Selects package sizing through `data-size`                                                |
+| `hint`            | `string`                          | `'暂无有效音频...'` | Empty-state text when no tip slot is supplied                                             |
+
+Unsupported custom-control environments always fall back to native `<audio controls>`, regardless
+of the requested mode. The component does not expose a `bridge` prop; use the headless composable
+for Bridge integration.
+
+## Events
+
+Component events describe `AudioSnapshot` transitions. They are not one-for-one proxies for native
+media events.
+
+| Event         | Payload                                           | When it fires                                                                                                                         |
+| ------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `statechange` | `(snapshot: AudioSnapshot)`                       | Every actual `PlaybackState` transition, including `loading`, `buffering`, and fatal `error`                                          |
+| `ready`       | `(snapshot: AudioSnapshot)`                       | State enters `ready`; normally after `canplay` while paused, or after a play request is rejected during loading; not a metadata alias |
+| `play`        | `(snapshot: AudioSnapshot)`                       | State enters `playing`; buffering recovery can fire it again without a new user command                                               |
+| `pause`       | `(snapshot: AudioSnapshot)`                       | State enters `paused`, including programmatic and exclusive-group pauses                                                              |
+| `ended`       | `(snapshot: AudioSnapshot)`                       | State enters `ended`; repeat/automatic playlist advance continues without this terminal transition                                    |
+| `timeupdate`  | `(currentTime: number, snapshot: AudioSnapshot)`  | Snapshot time changes; active playback updates can be more frequent than native `timeupdate`                                          |
+| `trackchange` | `(track: AudioTrack \| null, trackIndex: number)` | Selected track/index changes; read the initial track from the snapshot instead of relying on a mount callback                         |
+| `error`       | `(error: AudioPlayerError)`                       | A new public error appears; native media errors that advance to another source are not emitted                                        |
+
+```vue
+<VueAudioNative
+  src="/episode.mp3"
+  @ready="(snapshot) => console.log(snapshot.duration)"
+  @timeupdate="(seconds, snapshot) => saveProgress(snapshot.track?.id, seconds)"
+  @trackchange="(track, index) => console.log(index, track?.id)"
+  @error="(error) => handlePlaybackError(error.code)"
+/>
+```
+
+### Legacy events
+
+Version 1.x preserves the documented 0.x events:
+
+| Event           | Template listener | Payload                 | Mapping                                                                      |
+| --------------- | ----------------- | ----------------------- | ---------------------------------------------------------------------------- |
+| `on-change`     | `@on-change`      | `(playing: boolean)`    | `true` on entry to `playing`; `false` on entry to `paused` or `ended`        |
+| `on-timeupdate` | `@on-timeupdate`  | `(currentTime: number)` | Same time change as modern `timeupdate`, without the snapshot                |
+| `on-metadata`   | `@on-metadata`    | `(event: Event)`        | Raw `loadedmetadata` or `durationchange`; may fire more than once per source |
+| `on-audioId`    | `@on-audio-id`    | `(id: string)`          | Once after mount, for example `vue-audio-native-1`                           |
+
+Use `statechange` for loading/buffering/error UI; `on-change` only represents the legacy playing
+boolean.
+
+## Snapshot contract
+
+```ts
+interface AudioSnapshot {
+  state:
+    | 'idle'
+    | 'loading'
+    | 'ready'
+    | 'playing'
+    | 'paused'
+    | 'buffering'
+    | 'ended'
+    | 'error'
+  track: AudioTrack | null
+  trackIndex: number
+  currentTime: number
+  duration: number | null
+  buffered: readonly { start: number; end: number }[]
+  volume: number
+  muted: boolean
+  playbackRate: number
+  repeatMode: 'off' | 'one' | 'all'
+  error: AudioPlayerError | null
+}
+```
+
+Snapshots are new, top-level frozen objects. `duration` is `null` while unknown/invalid and
+`trackIndex` is `-1` when no track exists.
+
+`AUTOPLAY_BLOCKED` can coexist with `state: 'ready'` or `state: 'paused'`; it is not fatal. Let the
+user retry from a gesture. Fatal source failures enter `error` after all ordered sources are
+exhausted.
+
+Other error codes are `SOURCE_NOT_SUPPORTED`, `MEDIA_ABORTED`, `NETWORK`, `DECODE`, and `UNKNOWN`.
+Each error contains `code`, `message`, optional native `mediaErrorCode`, and optional `cause`.
+
+## Imperative handle
+
+The component exposes `AudioPlayerHandle` through a template ref:
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { VueAudioNative, type AudioPlayerHandle } from 'vue-audio-native'
+
+const player = ref<AudioPlayerHandle | null>(null)
+</script>
+
+<template>
+  <VueAudioNative ref="player" src="/episode.mp3" />
+  <button type="button" @click="void player?.play()">Play</button>
+</template>
+```
+
+| Method                                | Return                     | Behavior                                                                     |
+| ------------------------------------- | -------------------------- | ---------------------------------------------------------------------------- |
+| `play()`                              | `Promise<void>`            | Requests playback; rejects with a structured controller error                |
+| `pause()`                             | `void`                     | Pauses playback                                                              |
+| `toggle()`                            | `Promise<void>`            | Plays or pauses from the native paused state                                 |
+| `stop()`                              | `void`                     | Pauses and seeks to zero                                                     |
+| `seekTo(seconds)` / `skipBy(seconds)` | `void`                     | Absolute/relative seek under duration and buffer policy                      |
+| `selectTrack(index)`                  | `Promise<void>`            | Selects a valid integer index; out-of-range values throw `RangeError`        |
+| `previous()` / `next()`               | `Promise<void>`            | Playlist navigation; previous restarts the current track when past 3 seconds |
+| `setVolume(value)`                    | `void`                     | Clamps to `0`–`1`                                                            |
+| `setMuted(value)`                     | `void`                     | Updates mute state                                                           |
+| `setPlaybackRate(value)`              | `void`                     | Clamps to `0.25`–`4`                                                         |
+| `setRepeatMode(mode)`                 | `void`                     | Updates `off`, `one`, or `all`                                               |
+| `getElement()`                        | `HTMLAudioElement \| null` | Returns the current native element                                           |
+
+## Headless composable
+
+`useAudioPlayer()` accepts an `AudioControllerOptions` object, ref, computed value, or getter. It
+returns a shallow audio-element ref, a shallow immutable snapshot ref, and stable controls.
+
+```vue
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useAudioPlayer } from 'vue-audio-native'
+
+const source = computed(() => '/episode.mp3')
+const { audioRef, controls, snapshot } = useAudioPlayer(() => ({
+  src: source.value,
+  exclusive: true,
+  group: 'podcast',
+}))
+</script>
+
+<template>
+  <audio ref="audioRef" />
+  <button type="button" @click="void controls.toggle()">
+    {{ snapshot.state === 'playing' ? 'Pause' : 'Play' }}
+  </button>
+</template>
+```
+
+The composable reacts to input/options changes and destroys its controller with the current Vue
+effect scope.
+
+### WebView Bridge
+
+The headless options accept a protocol-neutral `bridge`:
+
+```ts
+import { useAudioPlayer, type AudioPlayerBridge } from 'vue-audio-native'
+
+const bridge: AudioPlayerBridge = {
+  emit(event) {
+    hostTransport.postMessage(JSON.stringify(event))
+  },
+}
+
+const player = useAudioPlayer({ src: '/episode.mp3', bridge })
+```
+
+Bridge event types are:
+
+- `{ type: 'statechange', snapshot }`
+- `{ type: 'trackchange', snapshot, track, trackIndex }`
+- `{ type: 'error', snapshot, error }`
+
+Removing the bridge or passing `null` detaches the old host before a simultaneous input update.
+Bridge exceptions are isolated from playback. Host code chooses its own WKWebView, Android
+`JavascriptInterface`, ArkWeb, or other transport protocol.
+
+## Slots
+
+| Slot              | Props                    | Behavior                                 |
+| ----------------- | ------------------------ | ---------------------------------------- |
+| `artwork`         | `{ track }`              | Replaces the default first artwork image |
+| `before-controls` | `{ controls, snapshot }` | Rendered before custom controls content  |
+| `after-controls`  | `{ controls, snapshot }` | Rendered after custom controls content   |
+| `tip`             | none                     | Preferred empty-state content            |
+| `slotTip`         | none                     | Legacy empty-state fallback              |
+
+The before/after control slots are not rendered while native controls are active.
 
 ## Styling
 
-Import `vue-audio-native/style.css`. It is standalone compiled CSS with no Tailwind Preflight,
-global utilities, shadcn, Reka or other UI runtime. Theme the player with:
+Import `vue-audio-native/style.css`. It contains no Tailwind Preflight, global utilities, shadcn,
+Reka, OKLCH, or `color-mix()` output.
 
 ```css
 .audio-native {
@@ -51,4 +367,13 @@ global utilities, shadcn, Reka or other UI runtime. Theme the player with:
 }
 ```
 
-See the repository migration guide for the complete legacy mapping and behavior changes.
+## SSR and browser boundary
+
+Importing the package is SSR safe. Media and DOM objects are used only after Vue mounts a real
+audio element. Capability detection—not user-agent parsing—selects custom versus native controls.
+Media Session is opt-in, native HLS is passed through when available, and no HLS engine or audio
+analysis runtime is bundled.
+
+Full Chinese API documentation is available at
+<https://trsoliu.github.io/vue-audio-native/api/>. The published `.d.ts` files remain the final
+machine-readable contract.

--- a/packages/vue-audio-native/package.json
+++ b/packages/vue-audio-native/package.json
@@ -30,10 +30,12 @@
     ".": {
       "import": {
         "types": "./dist/index.d.ts",
+        "development": "./dist/index.development.js",
         "default": "./dist/index.js"
       },
       "require": {
         "types": "./dist/index.d.cts",
+        "development": "./dist/index.development.cjs",
         "default": "./dist/index.cjs"
       }
     },

--- a/packages/vue-audio-native/scripts/build.ts
+++ b/packages/vue-audio-native/scripts/build.ts
@@ -16,4 +16,5 @@ await writeFile(
   resolve(outputDirectory, 'style.css.d.ts'),
   'declare const stylesheet: string\nexport default stylesheet\n',
 )
+await viteBuild({ configFile, mode: 'development' })
 await viteBuild({ configFile, mode: 'global' })

--- a/packages/vue-audio-native/scripts/check-pack.ts
+++ b/packages/vue-audio-native/scripts/check-pack.ts
@@ -54,7 +54,15 @@ assert.deepEqual(forbiddenPaths, [], `Unexpected packed files: ${forbiddenPaths.
 
 const manifest = JSON.parse(
   await readFile(resolve(packageRoot, 'package.json'), 'utf8'),
-) as { dependencies?: Record<string, string> }
+) as {
+  dependencies?: Record<string, string>
+  exports?: {
+    '.'?: {
+      import?: { development?: string }
+      require?: { development?: string }
+    }
+  }
+}
 const dependencyNames = Object.keys(manifest.dependencies ?? {})
 const forbiddenDependencies = dependencyNames.filter((name) =>
   /shadcn|radix|reka|sonner|class-variance-authority/i.test(name),
@@ -66,14 +74,32 @@ assert.deepEqual(
 )
 
 const esm = await readFile(resolve(packageRoot, 'dist/index.js'))
+const developmentEsm = await readFile(
+  resolve(packageRoot, 'dist/index.development.js'),
+)
 const css = await readFile(resolve(packageRoot, 'dist/style.css'))
 assert(gzipSync(esm).byteLength <= 25 * 1024, 'Component ESM exceeds 25 KB gzip')
 assert(gzipSync(css).byteLength <= 12 * 1024, 'Component CSS exceeds 12 KB gzip')
 
 const esmText = esm.toString('utf8')
+const developmentEsmText = developmentEsm.toString('utf8')
 assert(
-  esmText.includes('Multiple audio inputs were provided'),
-  'Published build lost the input precedence warning',
+  !esmText.includes('Multiple audio inputs were provided'),
+  'Published build retained the development-only input precedence warning',
+)
+assert(
+  developmentEsmText.includes('Multiple audio inputs were provided'),
+  'Development export lost the input precedence warning',
+)
+assert.equal(
+  manifest.exports?.['.']?.import?.development,
+  './dist/index.development.js',
+  'ESM development condition does not resolve the development build',
+)
+assert.equal(
+  manifest.exports?.['.']?.require?.development,
+  './dist/index.development.cjs',
+  'CommonJS development condition does not resolve the development build',
 )
 
 const cssText = css.toString('utf8')

--- a/packages/vue-audio-native/src/VueAudioNative.vue
+++ b/packages/vue-audio-native/src/VueAudioNative.vue
@@ -94,7 +94,7 @@ watch(
       Number(Number(trackCount) > 0) +
       Number(Boolean(modernSource)) +
       Number(Boolean(legacySource))
-    if (inputCount > 1) {
+    if (import.meta.env.DEV && inputCount > 1) {
       console.warn(
         '[vue-audio-native] Multiple audio inputs were provided. Using tracks, then src, then url.',
       )

--- a/packages/vue-audio-native/tests/component.test.ts
+++ b/packages/vue-audio-native/tests/component.test.ts
@@ -39,6 +39,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  vi.unstubAllEnvs()
   vi.restoreAllMocks()
 })
 
@@ -64,6 +65,21 @@ describe('VueAudioNative', () => {
 
     expect(wrapper.get('audio').attributes('src')).toContain('track-one.mp3')
     expect(warning).toHaveBeenCalledOnce()
+  })
+
+  it('does not warn about conflicting inputs in production', () => {
+    vi.stubEnv('DEV', false)
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    mount(VueAudioNative, {
+      props: {
+        src: '/modern.mp3',
+        tracks,
+        url: '/legacy.mp3',
+      },
+    })
+
+    expect(warning).not.toHaveBeenCalled()
   })
 
   it('preserves legacy props, events, slot, and audio id behavior', async () => {

--- a/packages/vue-audio-native/vite.config.ts
+++ b/packages/vue-audio-native/vite.config.ts
@@ -4,19 +4,25 @@ import { defineConfig } from 'vite'
 import dts from 'vite-plugin-dts'
 
 export default defineConfig(({ mode }) => {
+  const developmentBuild = mode === 'development'
   const globalBuild = mode === 'global'
+  const libraryBuild = mode === 'library'
 
   return {
     build: {
-      emptyOutDir: !globalBuild,
+      emptyOutDir: libraryBuild,
       lib: {
         cssFileName: 'style',
         entry: globalBuild ? 'src/global.ts' : 'src/index.ts',
         fileName: (format) =>
           format === 'es'
-            ? 'index.js'
+            ? developmentBuild
+              ? 'index.development.js'
+              : 'index.js'
             : format === 'cjs'
-              ? 'index.cjs'
+              ? developmentBuild
+                ? 'index.development.cjs'
+                : 'index.cjs'
               : 'vue-audio-native.global.js',
         formats: globalBuild ? ['iife'] : ['es', 'cjs'],
         name: 'VueAudioNative',
@@ -35,17 +41,20 @@ export default defineConfig(({ mode }) => {
       sourcemap: true,
       target: 'es2019',
     },
+    define: {
+      'import.meta.env.DEV': JSON.stringify(developmentBuild),
+    },
     plugins: [
       vue(),
       tailwindcss(),
-      ...(globalBuild
-        ? []
-        : [
+      ...(libraryBuild
+        ? [
             dts({
               bundleTypes: true,
               include: ['src'],
             }),
-          ]),
+          ]
+        : []),
     ],
   }
 })


### PR DESCRIPTION
## Summary

- keep volume and playback-rate snapshots finite for invalid integration input
- ship development-only Vue input-conflict warnings through conditional exports
- publish complete Vue and audio-core API, event, Bridge, and AI knowledge references
- verify production tarballs exclude Demo UI and development warnings

## Verification

- pnpm security:audit
- pnpm lint
- pnpm typecheck
- pnpm test:coverage
- pnpm build
- pnpm docs:build
- pnpm docs:index
- pnpm docs:audit
- pnpm docs:eval
- pnpm test:pack
- pnpm test:e2e (25 passed)
- Codex staged-change review: no actionable correctness issues