### PR TITLE
ci: add safe OIDC prerelease publishing

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,16 @@
+{
+  "mode": "pre",
+  "tag": "beta",
+  "initialVersions": {
+    "compatibility-lab": "0.0.0",
+    "demo-vue": "0.0.0",
+    "fixture-nuxt": "0.0.0",
+    "fixture-vite-vue": "0.0.0",
+    "@trsoliu/audio-core": "1.0.0-beta.1",
+    "vue-audio-native": "1.0.0-beta.2"
+  },
+  "changesets": [
+    "modern-audio-native",
+    "safe-vue-declarations"
+  ]
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,15 @@ on:
     branches:
       - master
   workflow_dispatch:
+    inputs:
+      release_before_sha:
+        description: Previous default-branch SHA from the failed release push
+        required: true
+        type: string
+      release_head_sha:
+        description: Exact release HEAD SHA from the failed release push
+        required: true
+        type: string
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -15,7 +24,7 @@ permissions:
 
 jobs:
   release:
-    if: github.repository == 'trsoliu/vue-audio-native'
+    if: github.repository == 'trsoliu/vue-audio-native' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     timeout-minutes: 40
     environment: npm
@@ -43,8 +52,17 @@ jobs:
       - run: pnpm test:pack
       - run: pnpm exec playwright install --with-deps chromium firefox webkit
       - run: pnpm test:e2e
+      - name: Inspect Changesets release state
+        id: release_state
+        run: pnpm release:inspect
+        env:
+          RELEASE_BEFORE_SHA: ${{ github.event_name == 'push' && github.event.before || inputs.release_before_sha }}
+          RELEASE_DEFAULT_BRANCH: master
+          RELEASE_EVENT_NAME: ${{ github.event_name }}
+          RELEASE_HEAD_SHA: ${{ github.event_name == 'push' && github.sha || inputs.release_head_sha }}
       - name: Create or update the release PR
         id: changesets
+        if: steps.release_state.outputs.prerelease_ready != 'true'
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1
         with:
           version: pnpm version-packages
@@ -52,10 +70,27 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Verify stable device-smoke evidence
-        if: steps.changesets.outputs.hasChangesets == 'false'
+        if: steps.release_state.outputs.mode == 'stable' && steps.changesets.outputs.hasChangesets == 'false'
         run: pnpm release:verify-devices
-      - name: Publish with npm Trusted Publishing
-        if: steps.changesets.outputs.hasChangesets == 'false'
+      - name: Publish stable packages with npm Trusted Publishing
+        if: steps.release_state.outputs.mode == 'stable' && steps.changesets.outputs.hasChangesets == 'false'
         run: pnpm release
+        env:
+          NPM_CONFIG_PROVENANCE: true
+      - name: Verify beta prerelease manifests
+        if: steps.release_state.outputs.mode == 'beta' && steps.release_state.outputs.prerelease_ready == 'true' && steps.release_state.outputs.release_commit == 'true'
+        run: pnpm release:verify-prerelease
+      - name: Reconfirm the live default-branch release head
+        id: release_head_recheck
+        if: steps.release_state.outputs.mode == 'beta' && steps.release_state.outputs.prerelease_ready == 'true' && steps.release_state.outputs.release_commit == 'true'
+        run: pnpm release:inspect
+        env:
+          RELEASE_BEFORE_SHA: ${{ github.event_name == 'push' && github.event.before || inputs.release_before_sha }}
+          RELEASE_DEFAULT_BRANCH: master
+          RELEASE_EVENT_NAME: ${{ github.event_name }}
+          RELEASE_HEAD_SHA: ${{ github.event_name == 'push' && github.sha || inputs.release_head_sha }}
+      - name: Publish beta packages to next with npm Trusted Publishing
+        if: steps.release_state.outputs.mode == 'beta' && steps.release_state.outputs.prerelease_ready == 'true' && steps.release_state.outputs.release_commit == 'true' && steps.release_head_recheck.outputs.release_commit == 'true'
+        run: pnpm release:next
         env:
           NPM_CONFIG_PROVENANCE: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ package changelogs are managed by Changesets.
 
 ## Unreleased
 
+- Added a mutually exclusive OIDC release path that waits until Changesets records every retained
+  beta changeset for a publishable package as consumed, binds publication to an ancestor-verified
+  versioning push, supports an exact-SHA-bound default-branch recovery after a failed release run,
+  reconfirms the live remote branch immediately before publication,
+  tolerates multi-commit rebase merges, and verifies exact `next` tags before
+  treating registry versions as complete while retrying transient registry failures; stable
+  publication still requires all four device-smoke rows.
 - Expanded the Vue and audio-core API references with every public option, event payload, snapshot
   state, error code, command, slot, Bridge event and npm README usage contract; also corrected the
   headless Vue template ref example and clarified that low-level controller values come from

--- a/docs/adr/0003-bootstrap-npm-publishing.md
+++ b/docs/adr/0003-bootstrap-npm-publishing.md
@@ -42,6 +42,35 @@ only.
 The temporary workflow is removed from the default branch after the beta and `legacy` sequence;
 its immutable Actions runs and Git history retain the audit trail.
 
+Routine follow-up betas use Changesets `beta` pre mode and the same trusted `release.yml`. Because
+Changesets retains source changeset files during pre mode, the workflow publishes only after every
+non-empty changeset that targets a publishable package is recorded in `pre.json` as consumed by the
+merged beta version PR; private Demo and fixture changesets do not block package publication. It
+also confirms that the triggering push both added a consumed changeset and changed at least one
+publishable manifest version. The event's previous default-branch SHA must remain an ancestor of
+the pushed `HEAD`, and the complete tree diff is limited to prerelease state, publishable manifests,
+generated package changelogs and the lockfile. This supports multi-commit rebase merges without
+allowing unrelated source changes. It then verifies every publishable manifest is
+`*-beta.N` and verifies exact internal dependency alignment. Changesets rejects a custom publish
+tag during active pre mode, so a typed, idempotent publisher checks exact registry versions,
+verifies `next` through bounded fresh/no-cache reads that tolerate transient registry failures
+before skipping, and invokes
+`npm publish --tag next --provenance` in dependency order only for versions that do not yet exist.
+The job is restricted to `master`, and adapter publication requires its exact core dependency to be
+available from the same run or npm. Outside active pre mode, the stable path still requires the
+device-smoke gate before an untagged Changesets publication.
+
+If the original release run cannot be rerun, a manual dispatch on `master` requires the previous
+default-branch SHA and exact release HEAD SHA from the failed push. The checked-out `HEAD` must
+still equal that supplied release SHA, and live `origin/master` must resolve to the same commit,
+before the version-only diff and state transition are accepted. Both push and manual paths repeat
+the live remote comparison immediately before npm publication, preserving the source-change and
+default-branch boundary even when another push races a running job.
+
+When pre mode was adopted, `modern-audio-native` and `safe-vue-declarations` were seeded as
+consumed because their contents were already represented by the public beta manifests. The later
+`clear-audio-api-docs` changeset remains pending and is the sole input to the next version PR.
+
 ## Alternatives considered
 
 ### Local interactive npm login
@@ -87,6 +116,8 @@ required npm package names, dist-tags or clean npm consumer verification.
   a new package has no stable version, then move `latest` to `1.0.0` at stable release.
 - Do not use or reintroduce the retained token; manually revoke it if the accepted risk changes.
 - Never use this workflow for stable versions; stable remains blocked by device-smoke evidence.
+- Keep prerelease and stable conditions mutually exclusive: pre mode can publish only to `next`,
+  while non-pre mode must pass the device gate.
 
 ## Follow-up actions
 

--- a/docs/wiki/release.mdx
+++ b/docs/wiki/release.mdx
@@ -44,6 +44,43 @@ npm 配置。完成顺序如下：
 保留 provenance，后续版本必须由 `.github/workflows/release.yml` 和 Trusted Publishing 的
 短期 OIDC 凭据发布。
 
+## 后续 beta（OIDC）
+
+后续 beta 在 Changesets `beta` pre mode 中生成版本，release PR 可以在真机表仍为“待验证”
+时合并。Changesets 在 pre mode 会保留源 changeset 文件，因此工作流只有在每个面向发布包
+的非空文件都已出现在 `pre.json` 的 consumed 列表中时，才认定 beta 版本 PR 已合并；仅面向
+私有 Demo/fixture 的 changeset 不阻塞 npm 发布，其他尚未消费的变更只会创建或更新版本 PR。
+工作流还要求当前 push 同时新增 consumed 记录并改变至少一个发布 manifest 的版本，确保只有
+version PR 的合并提交能够发布；失败时应重跑原 Actions run，后续普通提交不会补发旧版本。
+push 事件的 previous SHA 必须仍是 `HEAD` 的祖先，并且完整 diff 只能包含 pre state、发布
+manifests、生成的 package changelog 与 lockfile。这既兼容多提交 rebase merge，也会拒绝批量
+push 夹带未版本化源码。进入可发布状态后，工作流再确认 core 与 Vue manifests 都是
+`*-beta.N` 且 Vue 精确依赖本次 core，最后由 TypeScript 发布器按 core → Vue 顺序对 registry
+中尚不存在的版本执行 `npm publish --tag next --provenance`。对已存在版本，发布器会通过
+有界的 fresh/no-cache 重试确认 `next` 精确解析到该版本；查询期间的瞬时网络或 registry
+错误也会在同一窗口内重试，否则失败而不是把过期 dist-tag 当作成功。部分成功后重跑原 run
+仍然幂等。这条路径只使用 Trusted Publishing 的短期 OIDC 凭据与 provenance，不读取 npm
+token。
+
+如果原发布 run 已无法重跑，可在 `master` 手动 dispatch，并填写失败 push 记录中的 previous
+default-branch SHA 与 exact release HEAD SHA。工作流会先要求当前 `HEAD` 与填写的 release SHA
+完全一致，并实时确认 `origin/master` 仍指向同一提交，再复用相同的 consumed/version
+transition、祖先关系和完整 diff 白名单。push 与手动路径都会在 `npm publish` 前再次读取远端
+分支；版本提交后出现任何后续提交或运行中发生竞态 push 都会拒绝发布，因此恢复路径不会扩大
+发布边界。
+
+发布 job 只允许在 `master` 上运行；从 release PR 分支手动 dispatch 不会获得发布路径。
+适配器发布前还会确认其精确 `@trsoliu/audio-core` 版本已经由本次顺序发布或 npm registry
+提供，防止产生不可安装的依赖图。
+
+不处于 active pre mode（包括 `pre exit` 过渡）时，工作流只会走稳定发布分支，并继续
+强制执行四项真机门禁。因此 beta 发布不能把 `latest` 切到未验证的稳定版本，稳定发布也
+不能借用 `next` 路径绕过设备证据。
+
+本次切换已把随公开 beta 发布过的 `modern-audio-native` 与 `safe-vue-declarations` 记为
+consumed；发布时间晚于现有 beta 的 `clear-audio-api-docs` 仍保持 pending，并且是下一份
+version PR 的唯一变更输入。
+
 ## 证据不是声明
 
 本地 workspace link、成功的 `npm pack` 或桌面浏览器 E2E 都不能证明 registry 安装和宿主
@@ -55,7 +92,7 @@ commit SHA 与对应 CI URL。
 稳定版通过 GitHub Actions Trusted Publishing、OIDC 与 provenance 发布。工作流不保存长期
 npm token。`pnpm release:verify-devices` 会在 publish 之前解析[真机冒烟](../device-smoke/)
 的四个必需环境；任一状态不是精确的 `通过` 都会在 Actions 中阻断稳定发布，但不会阻止
-Changesets 创建或更新 release PR。
+Changesets 创建或更新 release PR，也不会阻止显式 pre mode 的 `next` 预发布。
 
 Vue 仓库采用 core 与组件协调版本。`pnpm version-packages` 在 Changesets 更新 manifests 后
 立即以 `--lockfile-only --ignore-scripts` 刷新 pnpm lockfile，保证生成的 release PR 仍可通过

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
     "changeset": "changeset",
     "version-packages": "changeset version && pnpm install --lockfile-only --ignore-scripts",
     "release": "changeset publish",
+    "release:inspect": "tsx scripts/release-state.ts packages/audio-core/package.json packages/vue-audio-native/package.json",
+    "release:next": "tsx scripts/publish-prerelease.ts packages/audio-core/package.json packages/vue-audio-native/package.json",
+    "release:verify-prerelease": "tsx scripts/prerelease-gate.ts packages/audio-core/package.json packages/vue-audio-native/package.json",
     "release:verify-devices": "tsx scripts/device-smoke-gate.ts docs/device-smoke.md"
   },
   "devDependencies": {

--- a/scripts/prerelease-gate.test.ts
+++ b/scripts/prerelease-gate.test.ts
@@ -1,0 +1,97 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { verifyPrereleasePackages } from './prerelease-gate'
+
+const temporaryDirectories: string[] = []
+
+async function createFixture(options: {
+  adapterVersion?: string
+  coreDependency?: string
+  coreVersion?: string
+} = {}): Promise<{ manifestPaths: string[]; repositoryRoot: string }> {
+  const repositoryRoot = await mkdtemp(join(tmpdir(), 'audio-prerelease-'))
+  temporaryDirectories.push(repositoryRoot)
+  await mkdir(join(repositoryRoot, '.changeset'), { recursive: true })
+  await mkdir(join(repositoryRoot, 'packages/core'), { recursive: true })
+  await mkdir(join(repositoryRoot, 'packages/adapter'), { recursive: true })
+
+  const coreVersion = options.coreVersion ?? '1.0.0-beta.2'
+  const adapterVersion = options.adapterVersion ?? '1.0.0-beta.3'
+  await writeFile(
+    join(repositoryRoot, '.changeset/pre.json'),
+    JSON.stringify({ mode: 'pre', tag: 'beta' }),
+  )
+  await writeFile(
+    join(repositoryRoot, 'packages/core/package.json'),
+    JSON.stringify({ name: '@trsoliu/audio-core', version: coreVersion }),
+  )
+  await writeFile(
+    join(repositoryRoot, 'packages/adapter/package.json'),
+    JSON.stringify({
+      dependencies: {
+        '@trsoliu/audio-core': options.coreDependency ?? coreVersion,
+      },
+      name: 'audio-adapter',
+      version: adapterVersion,
+    }),
+  )
+
+  return {
+    manifestPaths: [
+      'packages/core/package.json',
+      'packages/adapter/package.json',
+    ],
+    repositoryRoot,
+  }
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { force: true, recursive: true })),
+  )
+})
+
+describe('prerelease publication gate', () => {
+  it('accepts aligned beta manifests in Changesets pre mode', async () => {
+    const fixture = await createFixture()
+
+    await expect(
+      verifyPrereleasePackages(
+        fixture.repositoryRoot,
+        fixture.manifestPaths,
+      ),
+    ).resolves.toBeUndefined()
+  })
+
+  it('rejects a stable package version', async () => {
+    const fixture = await createFixture({ adapterVersion: '1.0.0' })
+
+    await expect(
+      verifyPrereleasePackages(
+        fixture.repositoryRoot,
+        fixture.manifestPaths,
+      ),
+    ).rejects.toThrow('must use a beta prerelease version')
+  })
+
+  it('rejects an unaligned exact internal dependency', async () => {
+    const fixture = await createFixture({
+      coreDependency: '1.0.0-beta.1',
+    })
+
+    await expect(
+      verifyPrereleasePackages(
+        fixture.repositoryRoot,
+        fixture.manifestPaths,
+      ),
+    ).rejects.toThrow(
+      'must depend on @trsoliu/audio-core@1.0.0-beta.2',
+    )
+  })
+})

--- a/scripts/prerelease-gate.ts
+++ b/scripts/prerelease-gate.ts
@@ -1,0 +1,124 @@
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+interface PackageManifest {
+  dependencies?: Record<string, string>
+  name?: unknown
+  optionalDependencies?: Record<string, string>
+  private?: unknown
+  version?: unknown
+}
+
+interface PrereleaseState {
+  mode?: unknown
+  tag?: unknown
+}
+
+interface VerifiedManifest {
+  dependencies: Record<string, string> | undefined
+  name: string
+  optionalDependencies: Record<string, string> | undefined
+  version: string
+}
+
+const betaVersionPattern =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)-beta\.(0|[1-9]\d*)$/
+
+async function readJson<T>(path: string): Promise<T> {
+  return JSON.parse(await readFile(path, 'utf8')) as T
+}
+
+export async function verifyPrereleasePackages(
+  repositoryRoot: string,
+  manifestPaths: readonly string[],
+): Promise<void> {
+  if (manifestPaths.length === 0) {
+    throw new Error('At least one publishable package manifest is required.')
+  }
+
+  const prereleaseState = await readJson<PrereleaseState>(
+    resolve(repositoryRoot, '.changeset/pre.json'),
+  )
+  if (prereleaseState.mode !== 'pre' || prereleaseState.tag !== 'beta') {
+    throw new Error(
+      'Changesets must be in beta pre mode before publishing to the next dist-tag.',
+    )
+  }
+
+  const manifests = await Promise.all(
+    manifestPaths.map(async (manifestPath): Promise<VerifiedManifest> => {
+      const manifest = await readJson<PackageManifest>(
+        resolve(repositoryRoot, manifestPath),
+      )
+      if (manifest.private === true) {
+        throw new Error(`${manifestPath} is private and cannot be published.`)
+      }
+      if (typeof manifest.name !== 'string' || manifest.name.length === 0) {
+        throw new Error(`${manifestPath} must declare a package name.`)
+      }
+      if (
+        typeof manifest.version !== 'string' ||
+        !betaVersionPattern.test(manifest.version)
+      ) {
+        throw new Error(
+          `${manifest.name} must use a beta prerelease version before next publication.`,
+        )
+      }
+
+      return {
+        dependencies: manifest.dependencies,
+        name: manifest.name,
+        optionalDependencies: manifest.optionalDependencies,
+        version: manifest.version,
+      }
+    }),
+  )
+
+  const manifestsByName = new Map(
+    manifests.map((manifest) => [manifest.name, manifest]),
+  )
+  if (manifestsByName.size !== manifests.length) {
+    throw new Error('Publishable package names must be unique.')
+  }
+
+  for (const manifest of manifests) {
+    for (const dependencies of [
+      manifest.dependencies,
+      manifest.optionalDependencies,
+    ]) {
+      for (const [dependencyName, dependencyVersion] of Object.entries(
+        dependencies ?? {},
+      )) {
+        const internalManifest = manifestsByName.get(dependencyName)
+        if (
+          internalManifest &&
+          dependencyVersion !== internalManifest.version
+        ) {
+          throw new Error(
+            `${manifest.name} must depend on ${dependencyName}@${internalManifest.version} before prerelease publication.`,
+          )
+        }
+      }
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const manifestPaths = process.argv.slice(2)
+  await verifyPrereleasePackages(process.cwd(), manifestPaths)
+  console.log(
+    `Verified ${manifestPaths.length} beta package manifest(s) for the next dist-tag.`,
+  )
+}
+
+const entryPath = process.argv[1]
+if (
+  entryPath &&
+  import.meta.url === pathToFileURL(resolve(entryPath)).href
+) {
+  void main().catch((error: unknown) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+}

--- a/scripts/publish-prerelease.test.ts
+++ b/scripts/publish-prerelease.test.ts
@@ -1,0 +1,275 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  lookupTaggedVersion,
+  publishPrereleasePackages,
+} from './publish-prerelease'
+
+const temporaryDirectories: string[] = []
+
+async function createFixture(): Promise<{
+  manifestPaths: string[]
+  repositoryRoot: string
+}> {
+  const repositoryRoot = await mkdtemp(join(tmpdir(), 'audio-publish-next-'))
+  temporaryDirectories.push(repositoryRoot)
+  await mkdir(join(repositoryRoot, '.changeset'), { recursive: true })
+  await mkdir(join(repositoryRoot, 'packages/core'), { recursive: true })
+  await mkdir(join(repositoryRoot, 'packages/adapter'), { recursive: true })
+  await writeFile(
+    join(repositoryRoot, '.changeset/pre.json'),
+    JSON.stringify({ mode: 'pre', tag: 'beta' }),
+  )
+  await writeFile(
+    join(repositoryRoot, 'packages/core/package.json'),
+    JSON.stringify({
+      name: '@trsoliu/audio-core',
+      publishConfig: { registry: 'https://registry.npmjs.org/' },
+      version: '1.0.0-beta.2',
+    }),
+  )
+  await writeFile(
+    join(repositoryRoot, 'packages/adapter/package.json'),
+    JSON.stringify({
+      dependencies: { '@trsoliu/audio-core': '1.0.0-beta.2' },
+      name: 'audio-adapter',
+      publishConfig: { registry: 'https://registry.npmjs.org/' },
+      version: '1.0.0-beta.3',
+    }),
+  )
+
+  return {
+    manifestPaths: [
+      'packages/core/package.json',
+      'packages/adapter/package.json',
+    ],
+    repositoryRoot,
+  }
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { force: true, recursive: true })),
+  )
+})
+
+describe('next prerelease publisher', () => {
+  it('accepts an existing version only when next resolves to that exact version', async () => {
+    const packageToPublish = {
+      dependencies: {},
+      directory: '/tmp/audio-core',
+      id: '@trsoliu/audio-core@1.0.0-beta.2',
+      manifestPath: 'packages/core/package.json',
+      name: '@trsoliu/audio-core',
+      registry: 'https://registry.npmjs.org/',
+      version: '1.0.0-beta.2',
+    }
+    const registryFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ version: '1.0.0-beta.1' }), {
+          status: 200,
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ version: '1.0.0-beta.2' }), {
+          status: 200,
+        }),
+      )
+
+    await expect(
+      lookupTaggedVersion(packageToPublish, {}, registryFetch),
+    ).resolves.toBe(false)
+    await expect(
+      lookupTaggedVersion(packageToPublish, {}, registryFetch),
+    ).resolves.toBe(true)
+    expect(String(registryFetch.mock.calls[0]?.[0])).toBe(
+      'https://registry.npmjs.org/%40trsoliu%2Faudio-core/next',
+    )
+  })
+
+  it('publishes unpublished packages sequentially in manifest order', async () => {
+    const fixture = await createFixture()
+    const publishedVersions = new Set<string>()
+    const publicationOrder: string[] = []
+
+    const result = await publishPrereleasePackages(
+      fixture.repositoryRoot,
+      fixture.manifestPaths,
+      {
+        isPublished: async ({ id }) => publishedVersions.has(id),
+        publish: async ({ id }) => {
+          publicationOrder.push(id)
+          publishedVersions.add(id)
+        },
+      },
+    )
+
+    expect(publicationOrder).toEqual([
+      '@trsoliu/audio-core@1.0.0-beta.2',
+      'audio-adapter@1.0.0-beta.3',
+    ])
+    expect(result).toEqual({
+      published: publicationOrder,
+      skipped: [],
+    })
+  })
+
+  it('does not invoke npm again when every exact version is already published', async () => {
+    const fixture = await createFixture()
+    const publish = vi.fn()
+
+    const result = await publishPrereleasePackages(
+      fixture.repositoryRoot,
+      fixture.manifestPaths,
+      {
+        isPublished: async () => true,
+        publish,
+      },
+    )
+
+    expect(publish).not.toHaveBeenCalled()
+    expect(result.published).toEqual([])
+    expect(result.skipped).toEqual([
+      '@trsoliu/audio-core@1.0.0-beta.2',
+      'audio-adapter@1.0.0-beta.3',
+    ])
+  })
+
+  it('rejects an existing immutable version when next points elsewhere', async () => {
+    const fixture = await createFixture()
+    const isTagged = vi.fn().mockResolvedValue(false)
+    const publish = vi.fn()
+
+    await expect(
+      publishPrereleasePackages(
+        fixture.repositoryRoot,
+        [fixture.manifestPaths[0]!],
+        {
+          isPublished: async () => true,
+          isTagged,
+          publish,
+          verificationAttempts: 1,
+          verificationDelayMs: 0,
+        },
+      ),
+    ).rejects.toThrow(
+      '@trsoliu/audio-core@1.0.0-beta.2 exists, but npm next does not resolve to it',
+    )
+    expect(publish).not.toHaveBeenCalled()
+    expect(isTagged).toHaveBeenLastCalledWith(
+      expect.objectContaining({ id: '@trsoliu/audio-core@1.0.0-beta.2' }),
+      { fresh: true },
+    )
+  })
+
+  it('recovers when a concurrent publish wins after the initial registry check', async () => {
+    const fixture = await createFixture()
+    const isPublished = vi
+      .fn()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true)
+
+    await expect(
+      publishPrereleasePackages(
+        fixture.repositoryRoot,
+        [fixture.manifestPaths[0]!],
+        {
+          isPublished,
+          publish: async () => {
+            throw new Error('version already exists')
+          },
+        },
+      ),
+    ).resolves.toEqual({
+      published: [],
+      skipped: ['@trsoliu/audio-core@1.0.0-beta.2'],
+    })
+    expect(isPublished).toHaveBeenLastCalledWith(
+      expect.objectContaining({ id: '@trsoliu/audio-core@1.0.0-beta.2' }),
+      { fresh: true },
+    )
+  })
+
+  it('keeps checking long enough for delayed npm registry propagation', async () => {
+    const fixture = await createFixture()
+    let registryChecks = 0
+
+    await expect(
+      publishPrereleasePackages(
+        fixture.repositoryRoot,
+        [fixture.manifestPaths[0]!],
+        {
+          isPublished: async () => {
+            registryChecks += 1
+            return registryChecks >= 8
+          },
+          publish: async () => undefined,
+          verificationDelayMs: 0,
+        },
+      ),
+    ).resolves.toEqual({
+      published: ['@trsoliu/audio-core@1.0.0-beta.2'],
+      skipped: [],
+    })
+    expect(registryChecks).toBe(8)
+  })
+
+  it('retries transient registry errors before and after npm accepts a publish', async () => {
+    const fixture = await createFixture()
+    const isPublished = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('temporary version lookup failure'))
+      .mockResolvedValueOnce(false)
+      .mockRejectedValueOnce(new Error('temporary propagation failure'))
+      .mockResolvedValue(true)
+    const isTagged = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('temporary next lookup failure'))
+      .mockResolvedValueOnce(true)
+
+    await expect(
+      publishPrereleasePackages(
+        fixture.repositoryRoot,
+        [fixture.manifestPaths[0]!],
+        {
+          isPublished,
+          isTagged,
+          publish: async () => undefined,
+          verificationAttempts: 3,
+          verificationDelayMs: 0,
+        },
+      ),
+    ).resolves.toEqual({
+      published: ['@trsoliu/audio-core@1.0.0-beta.2'],
+      skipped: [],
+    })
+    expect(isPublished).toHaveBeenCalledTimes(5)
+    expect(isTagged).toHaveBeenCalledTimes(2)
+  })
+
+  it('blocks adapter publication until its exact external core version exists', async () => {
+    const fixture = await createFixture()
+    const publish = vi.fn()
+
+    await expect(
+      publishPrereleasePackages(
+        fixture.repositoryRoot,
+        [fixture.manifestPaths[1]!],
+        {
+          isPublished: async () => false,
+          publish,
+        },
+      ),
+    ).rejects.toThrow(
+      '@trsoliu/audio-core@1.0.0-beta.2 must be published before audio-adapter@1.0.0-beta.3',
+    )
+    expect(publish).not.toHaveBeenCalled()
+  })
+})

--- a/scripts/publish-prerelease.ts
+++ b/scripts/publish-prerelease.ts
@@ -1,0 +1,357 @@
+import { readFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { spawn } from 'node:child_process'
+
+import { verifyPrereleasePackages } from './prerelease-gate'
+
+interface PublishManifest {
+  dependencies?: Record<string, unknown>
+  name?: unknown
+  publishConfig?: {
+    registry?: unknown
+  }
+  version?: unknown
+}
+
+export interface PrereleasePackage {
+  dependencies: Record<string, unknown>
+  directory: string
+  id: string
+  manifestPath: string
+  name: string
+  registry: string
+  version: string
+}
+
+interface PublicationAdapters {
+  isTagged?: (
+    packageToPublish: PrereleasePackage,
+    options?: { fresh?: boolean },
+  ) => Promise<boolean>
+  isPublished?: (
+    packageToPublish: PrereleasePackage,
+    options?: { fresh?: boolean },
+  ) => Promise<boolean>
+  publish?: (packageToPublish: PrereleasePackage) => Promise<void>
+  verificationAttempts?: number
+  verificationDelayMs?: number
+}
+
+interface PublicationResult {
+  published: string[]
+  skipped: string[]
+}
+
+const officialRegistry = 'https://registry.npmjs.org/'
+
+function resolveRegistry(registry: unknown): string {
+  const resolvedRegistry = registry ?? officialRegistry
+  if (typeof resolvedRegistry !== 'string') {
+    throw new Error('publishConfig.registry must be a string.')
+  }
+  const registryUrl = new URL(resolvedRegistry)
+  if (registryUrl.href !== officialRegistry) {
+    throw new Error(
+      `Prereleases must publish through the official npm registry, not ${registryUrl.href}.`,
+    )
+  }
+  return registryUrl.href
+}
+
+async function readPackage(
+  repositoryRoot: string,
+  manifestPath: string,
+): Promise<PrereleasePackage> {
+  const absoluteManifestPath = resolve(repositoryRoot, manifestPath)
+  const manifest = JSON.parse(
+    await readFile(absoluteManifestPath, 'utf8'),
+  ) as PublishManifest
+  if (typeof manifest.name !== 'string' || manifest.name.length === 0) {
+    throw new Error(`${manifestPath} must declare a package name.`)
+  }
+  if (typeof manifest.version !== 'string' || manifest.version.length === 0) {
+    throw new Error(`${manifest.name} must declare a package version.`)
+  }
+
+  return {
+    dependencies: manifest.dependencies ?? {},
+    directory: dirname(absoluteManifestPath),
+    id: `${manifest.name}@${manifest.version}`,
+    manifestPath,
+    name: manifest.name,
+    registry: resolveRegistry(manifest.publishConfig?.registry),
+    version: manifest.version,
+  }
+}
+
+async function lookupPublishedVersion(
+  packageToPublish: PrereleasePackage,
+  options: { fresh?: boolean } = {},
+): Promise<boolean> {
+  const endpoint = new URL(
+    `${encodeURIComponent(packageToPublish.name)}/${encodeURIComponent(packageToPublish.version)}`,
+    packageToPublish.registry,
+  )
+  if (options.fresh) {
+    endpoint.searchParams.set('release-check', `${Date.now()}`)
+  }
+  const response = await fetch(endpoint, {
+    headers: options.fresh
+      ? { accept: 'application/json', 'cache-control': 'no-cache' }
+      : { accept: 'application/json' },
+  })
+  if (response.status === 404) {
+    return false
+  }
+  if (!response.ok) {
+    throw new Error(
+      `npm registry returned ${response.status} while checking ${packageToPublish.id}.`,
+    )
+  }
+  return true
+}
+
+export async function lookupTaggedVersion(
+  packageToPublish: PrereleasePackage,
+  options: { fresh?: boolean } = {},
+  registryFetch: typeof fetch = fetch,
+): Promise<boolean> {
+  const endpoint = new URL(
+    encodeURIComponent(packageToPublish.name) + '/next',
+    packageToPublish.registry,
+  )
+  if (options.fresh) {
+    endpoint.searchParams.set('release-check', String(Date.now()))
+  }
+  const response = await registryFetch(endpoint, {
+    headers: options.fresh
+      ? { accept: 'application/json', 'cache-control': 'no-cache' }
+      : { accept: 'application/json' },
+  })
+  if (response.status === 404) return false
+  if (!response.ok) {
+    throw new Error(
+      'npm registry returned ' +
+        String(response.status) +
+        ' while checking the next tag for ' +
+        packageToPublish.id +
+        '.',
+    )
+  }
+  const metadata = (await response.json()) as { version?: unknown }
+  return metadata.version === packageToPublish.version
+}
+
+async function runNpmPublish(
+  packageToPublish: PrereleasePackage,
+): Promise<void> {
+  const executable = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+  const arguments_ = [
+    'publish',
+    '--tag',
+    'next',
+    '--access',
+    'public',
+    '--provenance',
+    '--registry',
+    packageToPublish.registry,
+  ]
+
+  await new Promise<void>((resolvePromise, rejectPromise) => {
+    const child = spawn(executable, arguments_, {
+      cwd: packageToPublish.directory,
+      env: { ...process.env, NPM_CONFIG_PROVENANCE: 'true' },
+      stdio: 'inherit',
+    })
+    child.once('error', rejectPromise)
+    child.once('exit', (code, signal) => {
+      if (code === 0) {
+        resolvePromise()
+        return
+      }
+      rejectPromise(
+        new Error(
+          `npm publish failed for ${packageToPublish.id} (${signal ?? `exit ${String(code)}`}).`,
+        ),
+      )
+    })
+  })
+}
+
+export async function publishPrereleasePackages(
+  repositoryRoot: string,
+  manifestPaths: readonly string[],
+  adapters: PublicationAdapters = {},
+): Promise<PublicationResult> {
+  await verifyPrereleasePackages(repositoryRoot, manifestPaths)
+  const packages = await Promise.all(
+    manifestPaths.map((manifestPath) =>
+      readPackage(repositoryRoot, manifestPath),
+    ),
+  )
+  const isVersionPublished = adapters.isPublished ?? lookupPublishedVersion
+  const useCombinedInjectedLookup =
+    adapters.isPublished !== undefined && adapters.isTagged === undefined
+  const isTagged = adapters.isTagged ?? lookupTaggedVersion
+  const publish = adapters.publish ?? runNpmPublish
+  const verificationAttempts = adapters.verificationAttempts ?? 12
+  const verificationDelayMs = adapters.verificationDelayMs ?? 5_000
+  if (
+    !Number.isInteger(verificationAttempts) ||
+    verificationAttempts < 1 ||
+    !Number.isFinite(verificationDelayMs) ||
+    verificationDelayMs < 0
+  ) {
+    throw new Error('Publication verification settings must be finite and positive.')
+  }
+  const result: PublicationResult = { published: [], skipped: [] }
+  const availableVersions = new Set<string>()
+  const packagesById = new Map(packages.map((package_) => [package_.id, package_]))
+
+  const waitBeforeRetry = async (): Promise<void> => {
+    await new Promise<void>((resolvePromise) => {
+      setTimeout(resolvePromise, verificationDelayMs)
+    })
+  }
+  const retryTransientLookup = async (
+    lookup: () => Promise<boolean>,
+  ): Promise<boolean> => {
+    let lastError: unknown
+    for (let attempt = 0; attempt < verificationAttempts; attempt += 1) {
+      try {
+        return await lookup()
+      } catch (error: unknown) {
+        lastError = error
+      }
+      if (attempt < verificationAttempts - 1) {
+        await waitBeforeRetry()
+      }
+    }
+    throw lastError
+  }
+
+  const publicationComplete = async (
+    packageToPublish: PrereleasePackage,
+    options: { fresh?: boolean } = {},
+  ): Promise<boolean> => {
+    if (!(await isVersionPublished(packageToPublish, options))) return false
+    return (
+      useCombinedInjectedLookup ||
+      (await isTagged(packageToPublish, options))
+    )
+  }
+  const waitForPublication = async (
+    packageToPublish: PrereleasePackage,
+  ): Promise<boolean> => {
+    for (let attempt = 0; attempt < verificationAttempts; attempt += 1) {
+      try {
+        if (await publicationComplete(packageToPublish, { fresh: true })) {
+          return true
+        }
+      } catch {
+        // A bounded retry handles transient registry and network failures.
+      }
+      if (attempt < verificationAttempts - 1) {
+        await waitBeforeRetry()
+      }
+    }
+    return false
+  }
+
+  for (const packageToPublish of packages) {
+    const audioCoreVersion = packageToPublish.dependencies['@trsoliu/audio-core']
+    if (audioCoreVersion !== undefined) {
+      if (
+        typeof audioCoreVersion !== 'string' ||
+        !/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-beta\.(0|[1-9]\d*))?$/.test(
+          audioCoreVersion,
+        )
+      ) {
+        throw new Error(
+          `${packageToPublish.name} must use an exact @trsoliu/audio-core version before prerelease publication.`,
+        )
+      }
+      const audioCoreId = `@trsoliu/audio-core@${audioCoreVersion}`
+      if (!availableVersions.has(audioCoreId)) {
+        const audioCorePackage = packagesById.get(audioCoreId) ?? {
+          dependencies: {},
+          directory: repositoryRoot,
+          id: audioCoreId,
+          manifestPath: `dependency of ${packageToPublish.manifestPath}`,
+          name: '@trsoliu/audio-core',
+          registry: officialRegistry,
+          version: audioCoreVersion,
+        }
+        if (
+          !(await retryTransientLookup(() =>
+            isVersionPublished(audioCorePackage, { fresh: true }),
+          ))
+        ) {
+          throw new Error(
+            `${audioCoreId} must be published before ${packageToPublish.id}.`,
+          )
+        }
+        availableVersions.add(audioCoreId)
+      }
+    }
+
+    if (
+      await retryTransientLookup(() => isVersionPublished(packageToPublish))
+    ) {
+      if (
+        !useCombinedInjectedLookup &&
+        !(await waitForPublication(packageToPublish))
+      ) {
+        throw new Error(
+          packageToPublish.id +
+            ' exists, but npm next does not resolve to it. Refusing to republish an immutable version.',
+        )
+      }
+      result.skipped.push(packageToPublish.id)
+      availableVersions.add(packageToPublish.id)
+      continue
+    }
+    try {
+      await publish(packageToPublish)
+    } catch (error: unknown) {
+      if (await waitForPublication(packageToPublish)) {
+        result.skipped.push(packageToPublish.id)
+        availableVersions.add(packageToPublish.id)
+        continue
+      }
+      throw error
+    }
+    if (!(await waitForPublication(packageToPublish))) {
+      throw new Error(
+        packageToPublish.id +
+          ' was accepted by npm, but the exact version and next tag were not both visible after verification.',
+      )
+    }
+    result.published.push(packageToPublish.id)
+    availableVersions.add(packageToPublish.id)
+  }
+
+  return result
+}
+
+async function main(): Promise<void> {
+  const result = await publishPrereleasePackages(
+    process.cwd(),
+    process.argv.slice(2),
+  )
+  if (result.published.length > 0) {
+    console.log(`Published to next: ${result.published.join(', ')}`)
+  }
+  if (result.skipped.length > 0) {
+    console.log(`Already published: ${result.skipped.join(', ')}`)
+  }
+}
+
+const entryPath = process.argv[1]
+if (entryPath && import.meta.url === pathToFileURL(resolve(entryPath)).href) {
+  void main().catch((error: unknown) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+}

--- a/scripts/release-state.test.ts
+++ b/scripts/release-state.test.ts
@@ -1,0 +1,398 @@
+import { execFile } from 'node:child_process'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { promisify } from 'node:util'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  detectPrereleaseVersionCommit,
+  inspectReleaseState,
+  isPrereleaseVersionCommit,
+} from './release-state'
+
+const temporaryDirectories: string[] = []
+const workspaceRoot = resolve(import.meta.dirname, '..')
+const execFileAsync = promisify(execFile)
+
+async function createFixture(options: {
+  changesetBody?: string
+  changesetId?: string
+  consumedChangesets?: string[]
+  mode?: 'exit' | 'pre'
+  withPrereleaseState?: boolean
+} = {}): Promise<string> {
+  const repositoryRoot = await mkdtemp(join(tmpdir(), 'audio-release-state-'))
+  temporaryDirectories.push(repositoryRoot)
+  await mkdir(join(repositoryRoot, '.changeset'), { recursive: true })
+
+  if (options.withPrereleaseState !== false) {
+    await writeFile(
+      join(repositoryRoot, '.changeset/pre.json'),
+      JSON.stringify({
+        changesets: options.consumedChangesets ?? [],
+        mode: options.mode ?? 'pre',
+        tag: 'beta',
+      }),
+    )
+  }
+
+  if (options.changesetId) {
+    await writeFile(
+      join(repositoryRoot, `.changeset/${options.changesetId}.md`),
+      options.changesetBody ??
+        '---\n"@trsoliu/audio-core": patch\n---\n\nA release change.\n',
+    )
+  }
+
+  return repositoryRoot
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { force: true, recursive: true })),
+  )
+})
+
+describe('Changesets release state', () => {
+  it('does not reconsider already-published bootstrap changesets', async () => {
+    const state = await inspectReleaseState(workspaceRoot)
+
+    if (state.mode === 'beta') {
+      expect(state.pendingChangesets).not.toContain('modern-audio-native')
+      expect(state.pendingChangesets).not.toContain('safe-vue-declarations')
+    }
+  })
+
+  it('accepts a versioning push or manual recovery and rejects unrelated events', () => {
+    const previousPrereleaseState = {
+      changesets: ['bootstrap'],
+      mode: 'pre',
+      tag: 'beta',
+    }
+    const currentPrereleaseState = {
+      changesets: ['bootstrap', 'next-change'],
+      mode: 'pre',
+      tag: 'beta',
+    }
+
+    expect(
+      isPrereleaseVersionCommit({
+        changedFiles: [
+          '.changeset/pre.json',
+          'packages/audio-core/package.json',
+        ],
+        currentPrereleaseState,
+        currentVersions: ['1.0.0-beta.2'],
+        eventName: 'push',
+        beforeIsAncestorOfHead: true,
+        manifestPaths: ['packages/audio-core/package.json'],
+        previousPrereleaseState,
+        previousVersions: ['1.0.0-beta.1'],
+      }),
+    ).toBe(true)
+    expect(
+      isPrereleaseVersionCommit({
+        changedFiles: [
+          '.changeset/pre.json',
+          'packages/audio-core/package.json',
+        ],
+        currentPrereleaseState,
+        currentVersions: ['1.0.0-beta.2'],
+        eventName: 'pull_request',
+        beforeIsAncestorOfHead: true,
+        manifestPaths: ['packages/audio-core/package.json'],
+        previousPrereleaseState,
+        previousVersions: ['1.0.0-beta.1'],
+      }),
+    ).toBe(false)
+    expect(
+      isPrereleaseVersionCommit({
+        changedFiles: [
+          '.changeset/pre.json',
+          'packages/audio-core/package.json',
+        ],
+        currentPrereleaseState,
+        currentVersions: ['1.0.0-beta.2'],
+        eventName: 'push',
+        beforeIsAncestorOfHead: true,
+        manifestPaths: ['packages/audio-core/package.json'],
+        previousPrereleaseState: currentPrereleaseState,
+        previousVersions: ['1.0.0-beta.2'],
+      }),
+    ).toBe(false)
+    expect(
+      isPrereleaseVersionCommit({
+        changedFiles: [
+          '.changeset/pre.json',
+          'packages/audio-core/package.json',
+        ],
+        currentPrereleaseState,
+        currentVersions: ['1.0.0-beta.2'],
+        eventName: 'workflow_dispatch',
+        beforeIsAncestorOfHead: true,
+        manifestPaths: ['packages/audio-core/package.json'],
+        previousPrereleaseState,
+        previousVersions: ['1.0.0-beta.1'],
+      }),
+    ).toBe(true)
+    expect(
+      isPrereleaseVersionCommit({
+        changedFiles: [
+          '.changeset/pre.json',
+          'packages/audio-core/package.json',
+          'packages/audio-core/src/index.ts',
+        ],
+        currentPrereleaseState,
+        currentVersions: ['1.0.0-beta.2'],
+        eventName: 'push',
+        beforeIsAncestorOfHead: true,
+        manifestPaths: ['packages/audio-core/package.json'],
+        previousPrereleaseState,
+        previousVersions: ['1.0.0-beta.1'],
+      }),
+    ).toBe(false)
+    expect(
+      isPrereleaseVersionCommit({
+        changedFiles: [
+          '.changeset/pre.json',
+          'packages/audio-core/package.json',
+        ],
+        currentPrereleaseState,
+        currentVersions: ['1.0.0-beta.2'],
+        eventName: 'push',
+        beforeIsAncestorOfHead: false,
+        manifestPaths: ['packages/audio-core/package.json'],
+        previousPrereleaseState,
+        previousVersions: ['1.0.0-beta.1'],
+      }),
+    ).toBe(false)
+  })
+
+  it('accepts a version-only rebase sequence when the previous tip remains an ancestor', async () => {
+    const repositoryRoot = await createFixture({
+      changesetId: 'next-change',
+      consumedChangesets: ['bootstrap'],
+    })
+    const packageDirectory = join(repositoryRoot, 'packages/audio-core')
+    await mkdir(packageDirectory, { recursive: true })
+    await writeFile(
+      join(packageDirectory, 'package.json'),
+      JSON.stringify({ name: '@trsoliu/audio-core', version: '1.0.0-beta.1' }),
+    )
+    await writeFile(join(packageDirectory, 'CHANGELOG.md'), '# Changelog\n')
+
+    await execFileAsync('git', ['init', '-b', 'main'], { cwd: repositoryRoot })
+    await execFileAsync('git', ['config', 'user.email', 'release@example.com'], {
+      cwd: repositoryRoot,
+    })
+    await execFileAsync('git', ['config', 'user.name', 'Release Test'], {
+      cwd: repositoryRoot,
+    })
+    await execFileAsync('git', ['add', '.'], { cwd: repositoryRoot })
+    await execFileAsync('git', ['commit', '-m', 'initial'], {
+      cwd: repositoryRoot,
+    })
+    const { stdout: beforeShaOutput } = await execFileAsync(
+      'git',
+      ['rev-parse', 'HEAD'],
+      { cwd: repositoryRoot, encoding: 'utf8' },
+    )
+
+    await writeFile(
+      join(packageDirectory, 'package.json'),
+      JSON.stringify({ name: '@trsoliu/audio-core', version: '1.0.0-beta.2' }),
+    )
+    await execFileAsync('git', ['add', '.'], { cwd: repositoryRoot })
+    await execFileAsync('git', ['commit', '-m', 'version package'], {
+      cwd: repositoryRoot,
+    })
+    await writeFile(
+      join(repositoryRoot, '.changeset/pre.json'),
+      JSON.stringify({
+        changesets: ['bootstrap', 'next-change'],
+        mode: 'pre',
+        tag: 'beta',
+      }),
+    )
+    await writeFile(
+      join(packageDirectory, 'CHANGELOG.md'),
+      '# Changelog\n\n## 1.0.0-beta.2\n',
+    )
+    await execFileAsync('git', ['add', '.'], { cwd: repositoryRoot })
+    await execFileAsync('git', ['commit', '-m', 'record prerelease state'], {
+      cwd: repositoryRoot,
+    })
+    const { stdout: releaseHeadShaOutput } = await execFileAsync(
+      'git',
+      ['rev-parse', 'HEAD'],
+      { cwd: repositoryRoot, encoding: 'utf8' },
+    )
+    const remoteRoot = await mkdtemp(join(tmpdir(), 'audio-release-remote-'))
+    temporaryDirectories.push(remoteRoot)
+    await execFileAsync(
+      'git',
+      ['init', '--bare', '--initial-branch=main', remoteRoot],
+      { cwd: repositoryRoot },
+    )
+    await execFileAsync('git', ['remote', 'add', 'origin', remoteRoot], {
+      cwd: repositoryRoot,
+    })
+    await execFileAsync('git', ['push', '--set-upstream', 'origin', 'main'], {
+      cwd: repositoryRoot,
+    })
+
+    await expect(
+      detectPrereleaseVersionCommit(
+        repositoryRoot,
+        ['packages/audio-core/package.json'],
+        {
+          beforeSha: beforeShaOutput.trim(),
+          defaultBranch: 'main',
+          eventName: 'push',
+          headSha: releaseHeadShaOutput.trim(),
+        },
+      ),
+    ).resolves.toBe(true)
+    await expect(
+      detectPrereleaseVersionCommit(
+        repositoryRoot,
+        ['packages/audio-core/package.json'],
+        {
+          beforeSha: beforeShaOutput.trim(),
+          eventName: 'workflow_dispatch',
+        },
+      ),
+    ).resolves.toBe(false)
+    await expect(
+      detectPrereleaseVersionCommit(
+        repositoryRoot,
+        ['packages/audio-core/package.json'],
+        {
+          beforeSha: beforeShaOutput.trim(),
+          defaultBranch: 'main',
+          eventName: 'workflow_dispatch',
+          headSha: releaseHeadShaOutput.trim(),
+        },
+      ),
+    ).resolves.toBe(true)
+
+    await execFileAsync(
+      'git',
+      ['checkout', '--detach', releaseHeadShaOutput.trim()],
+      { cwd: repositoryRoot },
+    )
+
+    const advancingCheckout = await mkdtemp(
+      join(tmpdir(), 'audio-release-advance-'),
+    )
+    temporaryDirectories.push(advancingCheckout)
+    await execFileAsync('git', ['clone', remoteRoot, advancingCheckout], {
+      cwd: repositoryRoot,
+    })
+    await execFileAsync(
+      'git',
+      ['config', 'user.email', 'release@example.com'],
+      { cwd: advancingCheckout },
+    )
+    await execFileAsync('git', ['config', 'user.name', 'Release Test'], {
+      cwd: advancingCheckout,
+    })
+    await writeFile(
+      join(advancingCheckout, 'packages/audio-core/CHANGELOG.md'),
+      '# Changelog\n\n## 1.0.0-beta.2\n\nFormatting follow-up.\n',
+    )
+    await execFileAsync('git', ['add', '.'], { cwd: advancingCheckout })
+    await execFileAsync('git', ['commit', '-m', 'refresh lockfile'], {
+      cwd: advancingCheckout,
+    })
+    await execFileAsync('git', ['push', 'origin', 'main'], {
+      cwd: advancingCheckout,
+    })
+    await expect(
+      detectPrereleaseVersionCommit(
+        repositoryRoot,
+        ['packages/audio-core/package.json'],
+        {
+          beforeSha: beforeShaOutput.trim(),
+          defaultBranch: 'main',
+          eventName: 'workflow_dispatch',
+          headSha: releaseHeadShaOutput.trim(),
+        },
+      ),
+    ).resolves.toBe(false)
+  })
+
+  it('requires a version PR while a non-empty prerelease changeset is pending', async () => {
+    const repositoryRoot = await createFixture({ changesetId: 'pending-change' })
+
+    await expect(inspectReleaseState(repositoryRoot)).resolves.toEqual({
+      mode: 'beta',
+      pendingChangesets: ['pending-change'],
+      prereleaseReady: false,
+    })
+  })
+
+  it('publishes after the version PR retains a consumed prerelease changeset', async () => {
+    const repositoryRoot = await createFixture({
+      changesetId: 'consumed-change',
+      consumedChangesets: ['consumed-change'],
+    })
+
+    await expect(inspectReleaseState(repositoryRoot)).resolves.toEqual({
+      mode: 'beta',
+      pendingChangesets: [],
+      prereleaseReady: true,
+    })
+  })
+
+  it('ignores an empty changeset when deciding prerelease readiness', async () => {
+    const repositoryRoot = await createFixture({
+      changesetBody: '---\n---\n\nNo package release.\n',
+      changesetId: 'empty-change',
+    })
+
+    await expect(inspectReleaseState(repositoryRoot)).resolves.toMatchObject({
+      mode: 'beta',
+      prereleaseReady: true,
+    })
+  })
+
+  it('ignores changesets that target only private workspaces', async () => {
+    const repositoryRoot = await createFixture({
+      changesetBody: '---\n"demo-vue": patch\n---\n\nDemo-only change.\n',
+      changesetId: 'demo-only',
+    })
+    const manifestPath = 'packages/audio-core/package.json'
+    await mkdir(join(repositoryRoot, 'packages/audio-core'), { recursive: true })
+    await writeFile(
+      join(repositoryRoot, manifestPath),
+      JSON.stringify({ name: '@trsoliu/audio-core', version: '1.0.0-beta.1' }),
+    )
+
+    await expect(
+      inspectReleaseState(repositoryRoot, [manifestPath]),
+    ).resolves.toEqual({
+      mode: 'beta',
+      pendingChangesets: [],
+      prereleaseReady: true,
+    })
+  })
+
+  it('treats absent and exit pre-state as stable release flows', async () => {
+    const stableRoot = await createFixture({ withPrereleaseState: false })
+    const exitRoot = await createFixture({ mode: 'exit' })
+
+    await expect(inspectReleaseState(stableRoot)).resolves.toMatchObject({
+      mode: 'stable',
+      prereleaseReady: false,
+    })
+    await expect(inspectReleaseState(exitRoot)).resolves.toMatchObject({
+      mode: 'stable',
+      prereleaseReady: false,
+    })
+  })
+})

--- a/scripts/release-state.ts
+++ b/scripts/release-state.ts
@@ -1,0 +1,480 @@
+import { execFile } from 'node:child_process'
+import { appendFile, readFile, readdir } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { promisify } from 'node:util'
+
+interface ChangesetsPrereleaseState {
+  changesets?: unknown
+  mode?: unknown
+  tag?: unknown
+}
+
+interface PackageVersionManifest {
+  name?: unknown
+  private?: unknown
+  version?: unknown
+}
+
+export interface PrereleaseVersionCommitInput {
+  changedFiles: readonly string[]
+  currentPrereleaseState: ChangesetsPrereleaseState
+  currentVersions: readonly unknown[]
+  eventName?: string | undefined
+  beforeIsAncestorOfHead: boolean
+  manifestPaths: readonly string[]
+  previousPrereleaseState: ChangesetsPrereleaseState
+  previousVersions: readonly unknown[]
+}
+
+export interface ReleaseState {
+  mode: 'beta' | 'stable'
+  pendingChangesets: string[]
+  prereleaseReady: boolean
+}
+
+const execFileAsync = promisify(execFile)
+
+function consumedChangesets(
+  state: ChangesetsPrereleaseState,
+): string[] | null {
+  if (
+    state.mode !== 'pre' ||
+    state.tag !== 'beta' ||
+    !Array.isArray(state.changesets) ||
+    state.changesets.some((changeset) => typeof changeset !== 'string')
+  ) {
+    return null
+  }
+  return state.changesets as string[]
+}
+
+export function isPrereleaseVersionCommit({
+  beforeIsAncestorOfHead,
+  changedFiles,
+  currentPrereleaseState,
+  currentVersions,
+  eventName,
+  manifestPaths,
+  previousPrereleaseState,
+  previousVersions,
+}: PrereleaseVersionCommitInput): boolean {
+  if (
+    (eventName !== 'push' && eventName !== 'workflow_dispatch') ||
+    !beforeIsAncestorOfHead
+  ) {
+    return false
+  }
+
+  const allowedFiles = new Set([
+    '.changeset/pre.json',
+    'pnpm-lock.yaml',
+    ...manifestPaths,
+    ...manifestPaths.map((manifestPath) => {
+      const separatorIndex = manifestPath.lastIndexOf('/')
+      const directory =
+        separatorIndex === -1 ? '' : manifestPath.slice(0, separatorIndex + 1)
+      return directory + 'CHANGELOG.md'
+    }),
+  ])
+  if (
+    !changedFiles.includes('.changeset/pre.json') ||
+    !manifestPaths.some((manifestPath) => changedFiles.includes(manifestPath)) ||
+    changedFiles.some((filePath) => !allowedFiles.has(filePath))
+  ) {
+    return false
+  }
+
+  const previousChangesets = consumedChangesets(previousPrereleaseState)
+  const currentChangesets = consumedChangesets(currentPrereleaseState)
+  if (!previousChangesets || !currentChangesets) return false
+
+  const previousSet = new Set(previousChangesets)
+  const currentSet = new Set(currentChangesets)
+  const consumedNewChangeset = currentChangesets.some(
+    (changeset) => !previousSet.has(changeset),
+  )
+  const retainedPreviousChangesets = previousChangesets.every((changeset) =>
+    currentSet.has(changeset),
+  )
+  const versionsAreComparable =
+    currentVersions.length > 0 &&
+    currentVersions.length === previousVersions.length &&
+    currentVersions.every((version) => typeof version === 'string') &&
+    previousVersions.every((version) => typeof version === 'string')
+  const versionChanged =
+    versionsAreComparable &&
+    currentVersions.some(
+      (version, index) => version !== previousVersions[index],
+    )
+
+  return consumedNewChangeset && retainedPreviousChangesets && versionChanged
+}
+
+function hasPackageRelease(
+  contents: string,
+  publishablePackageNames: ReadonlySet<string> | null,
+): boolean {
+  const normalizedContents = contents.replaceAll('\r\n', '\n')
+  const frontmatter = /^---\n([\s\S]*?)\n---(?:\n|$)/.exec(
+    normalizedContents,
+  )
+  const frontmatterBody = frontmatter?.[1]
+  if (!frontmatterBody) return false
+
+  const releasedPackages = frontmatterBody
+    .split('\n')
+    .map((line): string | null => {
+      const separatorIndex = line.lastIndexOf(':')
+      if (separatorIndex === -1) return null
+      const releaseType = line.slice(separatorIndex + 1).trim()
+      if (!['major', 'minor', 'patch'].includes(releaseType)) return null
+      const rawPackageName = line.slice(0, separatorIndex).trim()
+      const hasMatchingQuotes =
+        (rawPackageName.startsWith("'") && rawPackageName.endsWith("'")) ||
+        (rawPackageName.startsWith('"') && rawPackageName.endsWith('"'))
+      const packageName = hasMatchingQuotes
+        ? rawPackageName.slice(1, -1)
+        : rawPackageName
+      return packageName.length > 0 ? packageName : null
+    })
+    .filter((packageName): packageName is string => packageName !== null)
+
+  return publishablePackageNames
+    ? releasedPackages.some((packageName) =>
+        publishablePackageNames.has(packageName),
+      )
+    : releasedPackages.length > 0
+}
+
+async function readPrereleaseState(
+  prereleaseStatePath: string,
+): Promise<ChangesetsPrereleaseState | null> {
+  try {
+    return JSON.parse(
+      await readFile(prereleaseStatePath, 'utf8'),
+    ) as ChangesetsPrereleaseState
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return null
+    }
+    throw error
+  }
+}
+
+export async function inspectReleaseState(
+  repositoryRoot: string,
+  manifestPaths: readonly string[] = [],
+): Promise<ReleaseState> {
+  const changesetsDirectory = resolve(repositoryRoot, '.changeset')
+  const prereleaseState = await readPrereleaseState(
+    resolve(changesetsDirectory, 'pre.json'),
+  )
+
+  if (!prereleaseState || prereleaseState.mode === 'exit') {
+    return {
+      mode: 'stable',
+      pendingChangesets: [],
+      prereleaseReady: false,
+    }
+  }
+
+  if (prereleaseState.mode !== 'pre' || prereleaseState.tag !== 'beta') {
+    throw new Error(
+      'Changesets prerelease state must be pre/beta or exit before release automation runs.',
+    )
+  }
+  if (
+    !Array.isArray(prereleaseState.changesets) ||
+    prereleaseState.changesets.some(
+      (changeset) => typeof changeset !== 'string',
+    )
+  ) {
+    throw new Error(
+      'Changesets prerelease state must list the consumed changeset identifiers.',
+    )
+  }
+
+  const consumedChangesets = new Set(
+    prereleaseState.changesets as string[],
+  )
+  const publishablePackageNames =
+    manifestPaths.length === 0
+      ? null
+      : new Set(
+          await Promise.all(
+            manifestPaths.map(async (manifestPath): Promise<string> => {
+              const manifest =
+                await readCurrentJson<PackageVersionManifest>(
+                  repositoryRoot,
+                  manifestPath,
+                )
+              if (
+                manifest.private === true ||
+                typeof manifest.name !== 'string' ||
+                manifest.name.length === 0
+              ) {
+                throw new Error(
+                  `${manifestPath} must identify a publishable package.`,
+                )
+              }
+              return manifest.name
+            }),
+          ),
+        )
+  const changesetEntries = await readdir(changesetsDirectory, {
+    withFileTypes: true,
+  })
+  const pendingChangesets = (
+    await Promise.all(
+      changesetEntries
+        .filter(
+          (entry) =>
+            entry.isFile() &&
+            entry.name.endsWith('.md') &&
+            entry.name !== 'README.md',
+        )
+        .map(async (entry): Promise<string | null> => {
+          const changesetId = entry.name.slice(0, -'.md'.length)
+          if (consumedChangesets.has(changesetId)) {
+            return null
+          }
+          const contents = await readFile(
+            resolve(changesetsDirectory, entry.name),
+            'utf8',
+          )
+          return hasPackageRelease(contents, publishablePackageNames)
+            ? changesetId
+            : null
+        }),
+    )
+  )
+    .filter((changesetId): changesetId is string => changesetId !== null)
+    .sort()
+
+  return {
+    mode: 'beta',
+    pendingChangesets,
+    prereleaseReady: pendingChangesets.length === 0,
+  }
+}
+
+async function readCurrentJson<T>(
+  repositoryRoot: string,
+  filePath: string,
+): Promise<T> {
+  return JSON.parse(
+    await readFile(resolve(repositoryRoot, filePath), 'utf8'),
+  ) as T
+}
+
+async function readPreviousJson<T>(
+  repositoryRoot: string,
+  beforeSha: string,
+  filePath: string,
+): Promise<T | null> {
+  try {
+    const { stdout } = await execFileAsync(
+      'git',
+      ['show', beforeSha + ':' + filePath],
+      { cwd: repositoryRoot, encoding: 'utf8' },
+    )
+    return JSON.parse(stdout) as T
+  } catch {
+    return null
+  }
+}
+
+async function readGitOutput(
+  repositoryRoot: string,
+  arguments_: readonly string[],
+): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync('git', [...arguments_], {
+      cwd: repositoryRoot,
+      encoding: 'utf8',
+    })
+    return stdout.trim()
+  } catch {
+    return null
+  }
+}
+
+async function gitCommandSucceeds(
+  repositoryRoot: string,
+  arguments_: readonly string[],
+): Promise<boolean> {
+  try {
+    await execFileAsync('git', [...arguments_], { cwd: repositoryRoot })
+    return true
+  } catch {
+    return false
+  }
+}
+
+export async function detectPrereleaseVersionCommit(
+  repositoryRoot: string,
+  manifestPaths: readonly string[],
+  options: {
+    beforeSha?: string | undefined
+    defaultBranch?: string | undefined
+    eventName?: string | undefined
+    headSha?: string | undefined
+  } = {},
+): Promise<boolean> {
+  const beforeSha = options.beforeSha
+  if (
+    (options.eventName !== 'push' &&
+      options.eventName !== 'workflow_dispatch') ||
+    manifestPaths.length === 0
+  ) {
+    return false
+  }
+
+  const isValidBeforeSha = (sha: string): boolean =>
+    /^[a-f0-9]{40,64}$/i.test(sha) && !/^0+$/.test(sha)
+  if (!beforeSha || !isValidBeforeSha(beforeSha)) return false
+
+  const defaultBranch = options.defaultBranch
+  const requestedHeadSha = options.headSha
+  if (
+    (defaultBranch !== 'main' && defaultBranch !== 'master') ||
+    !requestedHeadSha ||
+    !isValidBeforeSha(requestedHeadSha)
+  ) {
+    return false
+  }
+  const currentHeadSha = await readGitOutput(repositoryRoot, [
+    'rev-parse',
+    'HEAD',
+  ])
+  const remoteHeadOutput = await readGitOutput(repositoryRoot, [
+    'ls-remote',
+    '--heads',
+    'origin',
+    `refs/heads/${defaultBranch}`,
+  ])
+  const remoteHeadFields = remoteHeadOutput?.split(/\s+/) ?? []
+  const remoteHeadSha = remoteHeadFields.length === 2 ? remoteHeadFields[0] : null
+  if (
+    currentHeadSha?.toLowerCase() !== requestedHeadSha.toLowerCase() ||
+    remoteHeadSha?.toLowerCase() !== requestedHeadSha.toLowerCase()
+  ) {
+    return false
+  }
+
+  return detectPrereleaseVersionCommitSince(
+    repositoryRoot,
+    manifestPaths,
+    beforeSha,
+    options.eventName,
+  )
+}
+
+async function detectPrereleaseVersionCommitSince(
+  repositoryRoot: string,
+  manifestPaths: readonly string[],
+  beforeSha: string,
+  eventName: string,
+): Promise<boolean> {
+  const previousPrereleaseState =
+    await readPreviousJson<ChangesetsPrereleaseState>(
+      repositoryRoot,
+      beforeSha,
+      '.changeset/pre.json',
+    )
+  if (!previousPrereleaseState) return false
+
+  const beforeIsAncestorOfHead = await gitCommandSucceeds(repositoryRoot, [
+    'merge-base',
+    '--is-ancestor',
+    beforeSha,
+    'HEAD',
+  ])
+  const changedFilesOutput = await readGitOutput(repositoryRoot, [
+    'diff',
+    '--name-only',
+    '--diff-filter=ACDMRT',
+    beforeSha,
+    'HEAD',
+  ])
+  if (!beforeIsAncestorOfHead || changedFilesOutput === null) return false
+  const changedFiles = changedFilesOutput
+    .split('\n')
+    .filter((filePath) => filePath.length > 0)
+
+  const currentPrereleaseState =
+    await readCurrentJson<ChangesetsPrereleaseState>(
+      repositoryRoot,
+      '.changeset/pre.json',
+    )
+  const previousManifests = await Promise.all(
+    manifestPaths.map((manifestPath) =>
+      readPreviousJson<PackageVersionManifest>(
+        repositoryRoot,
+        beforeSha,
+        manifestPath,
+      ),
+    ),
+  )
+  if (previousManifests.some((manifest) => manifest === null)) return false
+  const currentManifests = await Promise.all(
+    manifestPaths.map((manifestPath) =>
+      readCurrentJson<PackageVersionManifest>(repositoryRoot, manifestPath),
+    ),
+  )
+
+  return isPrereleaseVersionCommit({
+    beforeIsAncestorOfHead,
+    changedFiles,
+    currentPrereleaseState,
+    currentVersions: currentManifests.map((manifest) => manifest.version),
+    eventName,
+    manifestPaths,
+    previousPrereleaseState,
+    previousVersions: previousManifests.map((manifest) => manifest?.version),
+  })
+}
+
+async function main(): Promise<void> {
+  const manifestPaths = process.argv.slice(2)
+  const state = await inspectReleaseState(process.cwd(), manifestPaths)
+  const releaseCommit =
+    state.mode === 'beta'
+      ? await detectPrereleaseVersionCommit(
+          process.cwd(),
+          manifestPaths,
+          {
+            beforeSha: process.env.RELEASE_BEFORE_SHA,
+            defaultBranch: process.env.RELEASE_DEFAULT_BRANCH,
+            eventName: process.env.RELEASE_EVENT_NAME,
+            headSha: process.env.RELEASE_HEAD_SHA,
+          },
+        )
+      : false
+  const outputs = [
+    'release_commit=' + String(releaseCommit),
+    `mode=${state.mode}`,
+    `prerelease_ready=${String(state.prereleaseReady)}`,
+  ].join('\n')
+  const githubOutputPath = process.env.GITHUB_OUTPUT
+
+  if (githubOutputPath) {
+    await appendFile(githubOutputPath, `${outputs}\n`)
+  } else {
+    console.log(outputs)
+  }
+  if (state.pendingChangesets.length > 0) {
+    console.log(
+      `Pending prerelease changesets: ${state.pendingChangesets.join(', ')}`,
+    )
+  }
+}
+
+const entryPath = process.argv[1]
+if (entryPath && import.meta.url === pathToFileURL(resolve(entryPath)).href) {
+  void main().catch((error: unknown) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+}

--- a/scripts/release-workflow.test.ts
+++ b/scripts/release-workflow.test.ts
@@ -8,6 +8,14 @@ const workflowPath = resolve(repositoryRoot, '.github/workflows/release.yml')
 const packagePath = resolve(repositoryRoot, 'package.json')
 
 describe('stable npm release workflow', () => {
+  it('runs only from the repository default branch', async () => {
+    const workflow = await readFile(workflowPath, 'utf8')
+
+    expect(workflow).toContain(
+      "if: github.repository == 'trsoliu/vue-audio-native' && github.ref == 'refs/heads/master'",
+    )
+  })
+
   it('runs the device gate after versioning and before publication', async () => {
     const workflow = await readFile(workflowPath, 'utf8')
     const changesets = workflow.indexOf('id: changesets')
@@ -18,7 +26,66 @@ describe('stable npm release workflow', () => {
     expect(deviceGate).toBeGreaterThan(changesets)
     expect(publish).toBeGreaterThan(deviceGate)
     expect(workflow).toContain(
-      "if: steps.changesets.outputs.hasChangesets == 'false'",
+      "if: steps.release_state.outputs.mode == 'stable' && steps.changesets.outputs.hasChangesets == 'false'",
+    )
+  })
+
+  it('publishes prereleases only through the next dist-tag', async () => {
+    const workflow = await readFile(workflowPath, 'utf8')
+    const releaseState = workflow.indexOf('id: release_state')
+    const changesets = workflow.indexOf('id: changesets')
+    const prereleaseGate = workflow.indexOf('pnpm release:verify-prerelease')
+    const releaseHeadRecheck = workflow.indexOf('id: release_head_recheck')
+    const prereleasePublish = workflow.indexOf('\n        run: pnpm release:next\n')
+    const prereleaseCondition =
+      "if: steps.release_state.outputs.mode == 'beta' && steps.release_state.outputs.prerelease_ready == 'true' && steps.release_state.outputs.release_commit == 'true'"
+
+    expect(releaseState).toBeGreaterThan(-1)
+    expect(changesets).toBeGreaterThan(releaseState)
+    expect(prereleaseGate).toBeGreaterThan(changesets)
+    expect(releaseHeadRecheck).toBeGreaterThan(prereleaseGate)
+    expect(prereleasePublish).toBeGreaterThan(releaseHeadRecheck)
+    expect(workflow.split(prereleaseCondition)).toHaveLength(4)
+    expect(workflow).toContain(
+      "if: steps.release_state.outputs.prerelease_ready != 'true'",
+    )
+    expect(workflow).toContain('RELEASE_EVENT_NAME: ${{ github.event_name }}')
+    expect(workflow).toContain('release_before_sha:')
+    expect(workflow).toContain('release_head_sha:')
+    expect(workflow).toContain('RELEASE_DEFAULT_BRANCH: master')
+    expect(workflow).toContain(
+      "RELEASE_HEAD_SHA: ${{ github.event_name == 'push' && github.sha || inputs.release_head_sha }}",
+    )
+    expect(workflow).toContain(
+      "steps.release_head_recheck.outputs.release_commit == 'true'",
+    )
+    const betaConditions = workflow
+      .split('\n')
+      .filter((line) =>
+        line.includes("if: steps.release_state.outputs.mode == 'beta'"),
+      )
+    expect(betaConditions).toHaveLength(3)
+    expect(betaConditions.every((line) => !line.includes('hasChangesets'))).toBe(
+      true,
+    )
+
+    const packageJson = JSON.parse(await readFile(packagePath, 'utf8')) as {
+      scripts?: Record<string, string>
+    }
+    expect(packageJson.scripts?.['release:next']).toContain(
+      'scripts/publish-prerelease.ts',
+    )
+    expect(packageJson.scripts?.['release:next']).not.toContain(
+      'changeset publish',
+    )
+    expect(packageJson.scripts?.['release:verify-prerelease']).toContain(
+      'scripts/prerelease-gate.ts',
+    )
+    expect(packageJson.scripts?.['release:inspect']).toContain(
+      'scripts/release-state.ts',
+    )
+    expect(packageJson.scripts?.['release:inspect']).toContain(
+      'packages/audio-core/package.json',
     )
   })
 


### PR DESCRIPTION
## Summary\n\n- add Changesets beta prerelease state and release-state inspection\n- publish with GitHub Actions OIDC Trusted Publishing and provenance\n- enforce exact core dependency, default-branch SHA freshness, release-diff allowlist, registry next-tag checks, and idempotent retries\n- keep stable publishing blocked by the required device-smoke gate\n- document manual recovery and release contracts\n\n## Verification\n\nAll repository release gates passed locally:\n\n- security audit\n- lint\n- typecheck\n- coverage\n- build\n- docs build/index/audit/eval\n- package validation\n- Playwright E2E (25/25)\n\nTargeted release workflow regression tests also pass, including detached-checkout stale-head rejection.