### PR TITLE
docs: record Vue Audio Native 1.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,23 @@ package changelogs are managed by Changesets.
 
 ## Unreleased
 
+- No changes have been recorded after 1.0.1.
+
+## 1.0.1 - 2026-07-30
+
+- Published `@trsoliu/audio-core@1.0.1` and `vue-audio-native@1.0.1` through OIDC Trusted
+  Publishing with provenance, then verified fresh Vite Vue and Nuxt SSR registry consumers.
 - Corrected the stable npm installation guidance for core and Vue, and made Changesets keep package
   README version examples synchronized with every generated release.
 - Restricted stable OIDC publication to an allowlisted Changesets version commit and repeated the
   live default-branch head check immediately before publishing.
+- Preserved `vue-audio-native@legacy` at `0.1.41` and both prerelease lines on their existing `next`
+  tags.
+- Changed no runtime audio behavior from 1.0.0; the maintainer accepted the explicitly documented
+  residual risk from unexecuted physical WebView device tests.
+
+## 1.0.0 - 2026-07-30
+
 - Published `@trsoliu/audio-core@1.0.0` and `vue-audio-native@1.0.0` with provenance, kept Vue 2 on
   `vue-audio-native@legacy`, and verified clean Vite, Nuxt, React and Next registry consumers.
 - Accepted the maintainer's version-bound automated compatibility assessment for stable 1.0.0,

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -15,8 +15,9 @@ Vue Audio Native 1.0 不只是一个播放器组件。它把浏览器媒体状�
 
 ## 当前发布状态
 
-- `@trsoliu/audio-core@1.0.0` 与 `vue-audio-native@1.0.0` 已通过 OIDC Trusted Publishing
-  发布到 npm 的 `latest`，均携带 SLSA provenance；`next` 保留最后一个 beta。
+- `@trsoliu/audio-core@1.0.1` 与 `vue-audio-native@1.0.1` 已通过 OIDC Trusted Publishing
+  发布到 npm 的 `latest`，均携带 SLSA provenance；本次补丁只更新安装指引与发布安全性，
+  不改变 1.0.0 的音频运行时行为，`next` 保留最后一个 beta。
 - Vue 2 继续使用 `vue-audio-native@legacy`，当前解析到 `0.1.41`。
 - 稳定版采用维护者的版本绑定评估授权；未执行的真机场景与剩余风险在
   [兼容性评估与真机记录](./device-smoke/)中如实保留。

--- a/docs/wiki/release.mdx
+++ b/docs/wiki/release.mdx
@@ -14,6 +14,8 @@ description: beta、stable、npm dist-tag、Trusted Publishing 与干净消费�
 5. 在完全干净的 Vite、Nuxt、React 和 Next 消费者中验证 registry 包与精确 core 依赖。
 6. 三个包与干净消费者回归全部通过后，将 `vue-audio-native@0.1.41` 设置为 `legacy`。
 7. 稳定 1.0 由完整真机证据或维护者版本绑定评估授权二选一放行，随后只通过 OIDC 发布。
+8. 1.0.1 通过同一评估路径发布 core 与 Vue 的文档和发布安全补丁，并用全新 Vite Vue 与
+   Nuxt SSR 消费者复核 npm Registry；这次补丁没有改变音频运行时。
 
 ## 首次 beta 引导发布（已完成）
 
@@ -98,7 +100,12 @@ npm token。`pnpm release:verify-stable` 会在 publish 之前解析
 [兼容性评估与真机记录](../device-smoke/)：四个必需环境都精确为 `通过` 时采用真机证据；
 否则必须提供维护者、ISO 日期、精确稳定版本覆盖、自动化评估 `通过` 和剩余风险 `已接受`。
 工作流会要求所有传入 manifest 要么匹配单一共享版本，要么被完整的 `包名@版本` 映射精确覆盖。
-1.0.0 采用维护者评估路径，未执行的真机项保持明确标记，不会被写成通过。
+1.0.0 与 1.0.1 采用维护者评估路径，未执行的真机项保持明确标记，不会被写成通过。
+
+1.0.1 的稳定发布流水线、npm provenance 与 Registry 消费者验证已于 2026-07-30 完成；
+`@trsoliu/audio-core@latest` 和 `vue-audio-native@latest` 均解析到 1.0.1，Vue 精确依赖同版本
+core，`legacy` 仍解析到 0.1.41。对应 GitHub Release 为
+[Vue Audio Native 1.0.1](https://github.com/trsoliu/vue-audio-native/releases/tag/v1.0.1)。
 
 Vue 仓库采用 core 与组件协调版本。`pnpm version-packages` 在 Changesets 更新 manifests 后，
 同步重写两个 package README 的受管理安装区，再以 `--lockfile-only --ignore-scripts` 刷新


### PR DESCRIPTION
## Summary

- records the published core and Vue 1.0.1 versions
- links the GitHub Release and documents the verified registry consumers
- preserves the accepted physical WebView residual risk without claiming device execution

## Verification

- pnpm docs:build
- pnpm docs:index
- pnpm docs:audit
- pnpm docs:eval
- git diff --check

This is a documentation-only post-release update and intentionally has no Changeset.